### PR TITLE
Allow custom headers on list_objects requests

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -171,7 +171,7 @@ defmodule ExAws.S3 do
     params = opts
     |> format_and_take(@params)
 
-    request(:get, bucket, "/", [params: params],
+    request(:get, bucket, "/", [params: params, headers: opts[:headers]],
       stream_builder: &ExAws.S3.Lazy.stream_objects!(bucket, opts, &1),
       parser: &ExAws.S3.Parsers.parse_list_objects/1
     )

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -2,6 +2,22 @@ defmodule ExAws.S3Test do
   use ExUnit.Case, async: true
   alias ExAws.{S3, Operation}
 
+  test "#list_objects" do
+    res = S3.list_objects("bucket",
+                        headers: %{"x-amz-request-payer" => "requester"},
+                        prefix: "/path/to/objs")
+    %Operation.S3{
+      headers: headers,
+      params: params,
+      bucket: bucket,
+      http_method: http_method
+    } = res
+    assert headers == %{"x-amz-request-payer" => "requester"}
+    assert params == %{"prefix" => "/path/to/objs"}
+    assert bucket == "bucket"
+    assert http_method == :get
+  end
+
   test "#get_object" do
     expected = %Operation.S3{bucket: "bucket", headers: %{"x-amz-server-side-encryption-customer-algorithm" => "md5"}, params: %{"response-content-type" => "application/json"}, path: "object.json", http_method: :get}
     assert expected == S3.get_object("bucket", "object.json", response: [content_type: "application/json"], encryption: [customer_algorithm: "md5"])


### PR DESCRIPTION
My use case was specifically to perform the `list_objects` operation leveraging S3 requester pays functionality.  This requires the inclusion of `x-amz-request-payer : requester` header.

Source: http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html
```
"After you configure a bucket to be a Requester Pays bucket, requesters must include x-amz-request-payer in their requests either in the header, for POST, GET and HEAD requests, or as a parameter in a REST request to show that they understand that they will be charged for the request and the data download."
```

I felt this was the least intrusive change to achieve the desired functionality.  A later conversation might be full blown support for this S3 feature in a separate GH issue.

Usage:
``` elixir
ExAws.S3.list_objects("bucket", headers: %{"x-amz-request-payer" => "requester"})
```

New Test: `mix test test/lib/s3_test.exs:5` (some existing failing tests so this isolates execution of my new test)