### PR TITLE
Add multipart streaming capabilities to get_object

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -463,7 +463,11 @@ defmodule ExAws.S3 do
     |> build_encryption_headers
     |> Map.merge(headers)
 
-    request(:get, bucket, object, headers: headers, params: response_opts)
+    request(:get, bucket, object,
+      [headers: headers, params: response_opts],
+      stream_builder: fn config ->
+          ExAws.S3.Lazy.get_object!(bucket, object, opts, config)
+      end)
   end
 
   @type download_file_opts :: [

--- a/lib/ex_aws/s3/download.ex
+++ b/lib/ex_aws/s3/download.ex
@@ -14,60 +14,17 @@ defmodule ExAws.S3.Download do
 
   @type t :: %__MODULE__{}
 
-  def get_chunk(op, %{start_byte: start_byte, end_byte: end_byte}, config) do
-    %{body: body} =
-      op.bucket
-      |> ExAws.S3.get_object(op.path, [range: "bytes=#{start_byte}-#{end_byte}"])
-      |> ExAws.request!(config)
-
-    {start_byte, body}
-  end
-
-  def build_chunk_stream(op, config) do
-    op.bucket
-    |> get_file_size(op.path, config)
-    |> chunk_stream(op.opts[:chunk_size] || 1024 * 1024)
-  end
-
-  def chunk_stream(file_size, chunk_size) do
-    Stream.unfold(0, fn counter ->
-      start_byte = counter * chunk_size
-
-      if start_byte >= file_size do
-        nil
-      else
-        end_byte = (counter + 1) * chunk_size
-
-        # byte ranges are inclusive, so we want to remove one. IE, first 500 bytes
-        # is range 0-499. Also, we need it bounded by the max size of the file
-        end_byte = min(end_byte, file_size) - 1
-
-        {%{start_byte: start_byte, end_byte: end_byte}, counter + 1}
-      end
-    end)
-  end
-
-  defp get_file_size(bucket, path, config) do
-    %{headers: headers} = ExAws.S3.head_object(bucket, path) |> ExAws.request!(config)
-
-    headers
-    |> List.keyfind("Content-Length", 0, nil)
-    |> elem(1)
-    |> String.to_integer
-  end
 end
 
 defimpl ExAws.Operation, for: ExAws.S3.Download do
 
-  alias ExAws.S3.Download
-
   def perform(op, config) do
     file = File.open!(op.dest, [:write, :delayed_write, :binary])
 
-    op
-    |> Download.build_chunk_stream(config)
-    |> Task.async_stream(fn boundaries ->
-      chunk = Download.get_chunk(op, boundaries, config)
+    opts = Keyword.merge([chunk_size: 1024*1024], op.opts)
+    ExAws.S3.get_object(op.bucket, op.path, opts)
+    |> ExAws.stream!(config)
+    |> Task.async_stream(fn chunk ->
       :ok = :file.pwrite(file, [chunk])
     end,
       max_concurrency: Keyword.get(op.opts, :max_concurrency, 8),

--- a/lib/ex_aws/s3/lazy.ex
+++ b/lib/ex_aws/s3/lazy.ex
@@ -22,10 +22,35 @@ defmodule ExAws.S3.Lazy do
     end, &(&1))
   end
 
+  def get_object!(bucket, object, opts, config) do
+    file_size = object_size(bucket, object, config)
+    chunk_size = Map.get(opts, :chunk_size, file_size)
+    Stream.unfold(0, fn chunk_number ->
+      from = chunk_number * chunk_size
+      to = min((chunk_number+1)*chunk_size, file_size)-1
+      case from >= file_size do
+        true ->
+          nil
+        false ->
+          %{body: chunk} =
+            ExAws.S3.get_object(bucket, object, range: "bytes=#{from}-#{to}")
+            |> ExAws.request!(config)
+          {{from, chunk}, chunk_number+1}
+      end
+    end)
+  end
+
   def next_marker(%{next_marker: "", contents: contents}) do
     contents
     |> List.last
     |> Map.fetch!(:key)
   end
   def next_marker(%{next_marker: marker}), do: marker
+
+  defp object_size(bucket, path, config) do
+    %{headers: headers} = ExAws.S3.head_object(bucket, path)
+                        |> ExAws.request!(config)
+    {_, size} = List.keyfind(headers, "Content-Length", 0)
+    String.to_integer(size)
+  end
 end

--- a/test/lib/s3/integration_test.exs
+++ b/test/lib/s3/integration_test.exs
@@ -1,9 +1,56 @@
 defmodule ExAws.S3IntegrationTest do
   use ExUnit.Case, async: true
 
+  import Support.BypassHelpers
+  setup [:start_bypass]
+
   test "#list_buckets" do
     assert {:ok, %{body: body}} = ExAws.S3.list_buckets |> ExAws.request
     assert %{buckets: _} = body
+  end
+
+  test "get_object can generate a stream with one chunk", %{bypass: bypass} do
+    file = :crypto.strong_rand_bytes(10 * 1024 * 1024)
+    given_file_accessible_with_bypass("bucket", "object", file, bypass)
+
+    stream = ExAws.S3.get_object("bucket", "object")
+           |> ExAws.stream!(exaws_config_for_bypass(bypass))
+
+    assert [{0, ^file}] = Enum.to_list(stream)
+  end
+
+  test "get_object can generate a stream with multiple chunks",
+    %{bypass: bypass} do
+    file = :crypto.strong_rand_bytes(10 * 1024 * 1024 + 15)
+    given_file_accessible_with_bypass("bucket", "object", file, bypass)
+
+    chunks = ExAws.S3.get_object("bucket", "object", chunk_size: 1024*1024)
+           |> ExAws.stream!(exaws_config_for_bypass(bypass))
+           |> Enum.to_list()
+
+    assert Enum.count(chunks) == 11
+    assert Enum.map(chunks, fn {_, c} -> c end) |> Enum.into(<<>>) == file
+  end
+
+  defp given_file_accessible_with_bypass(bucket, object, content, bypass) do
+    content_size = byte_size(content) |> to_string
+    request_path = "/#{bucket}/#{object}"
+    Bypass.expect bypass, fn conn ->
+      case conn do
+        %{method: "HEAD", request_path: ^request_path} ->
+          conn
+          |> Plug.Conn.put_resp_header("Content-Length", content_size)
+          |> Plug.Conn.send_resp(200, "")
+        %{method: "GET", req_headers: hdrs, request_path: ^request_path} ->
+          {"range", "bytes=" <> range} = List.keyfind(hdrs, "range", 0)
+          [from, to] = String.split(range, "-")
+          part = :binary.part(content,
+            String.to_integer(from),
+            String.to_integer(to) - String.to_integer(from) + 1)
+          conn
+          |> Plug.Conn.send_resp(200, part)
+      end
+    end
   end
 
 end

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -3,8 +3,14 @@ defmodule ExAws.S3Test do
   alias ExAws.{S3, Operation}
 
   test "#get_object" do
-    expected = %Operation.S3{bucket: "bucket", headers: %{"x-amz-server-side-encryption-customer-algorithm" => "md5"}, params: %{"response-content-type" => "application/json"}, path: "object.json", http_method: :get}
-    assert expected == S3.get_object("bucket", "object.json", response: [content_type: "application/json"], encryption: [customer_algorithm: "md5"])
+    expected = %Operation.S3{
+      bucket: "bucket",
+      headers: %{"x-amz-server-side-encryption-customer-algorithm" => "md5"},
+      params: %{"response-content-type" => "application/json"},
+      path: "object.json", http_method: :get}
+    assert expected == S3.get_object("bucket", "object.json",
+      response: [content_type: "application/json"],
+      encryption: [customer_algorithm: "md5"]) |> Map.put(:stream_builder, nil)
   end
 
   test "#put_object" do


### PR DESCRIPTION
This adds a possibility of getting a large object in chunks as a stream, and therefore creating a processing pipeline (together with multipart upload) without loading the whole input files and keeping the whole output file in memory (MapReduce style).

An example to come...

I still feel like there is a test missing for chunkified upload and download.
Perhaps [fake-s3](/jubos/fake-s3) could be used for integration tests?