### PR TITLE
fix performance issue in multipart upload

### DIFF
--- a/lib/ex_aws/s3/upload.ex
+++ b/lib/ex_aws/s3/upload.ex
@@ -82,7 +82,7 @@ defimpl ExAws.Operation, for: ExAws.S3.Upload do
     with {:ok, op} <- Upload.initialize(op, config) do
       op.src
       |> Stream.with_index(1)
-      |> Task.async_stream(&Upload.upload_chunk!(&1, op, config),
+      |> Task.async_stream(Upload, :upload_chunk!, [Map.delete(op, :src), config],
         max_concurrency: Keyword.get(op.opts, :max_concurrency, 4),
         timeout: Keyword.get(op.opts, :timeout, 30_000)
       )


### PR DESCRIPTION
op, including op.src, has to be copied to the new process spawned by Task.async_stream, and if op.src is "big enough" this can take a while and negates the performance wins from parallel execution.

* remove :src from op as it is not needed in the task
* use the (Module, :function, [args]) form, as &(...) creates a closure that captures all variables present in the scope (including the original op with :src)