### PR TITLE
Use non-bang version of request in example

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -24,13 +24,13 @@ defmodule ExAws.S3 do
   "path/to/big/file"
   |> S3.Upload.stream_file
   |> S3.upload("my-bucket", "path/on/s3")
-  |> ExAws.request! #=> {:ok, :done}
+  |> ExAws.request #=> {:ok, :done}
   ```
 
   Download large file to disk
   ```
   S3.download_file("my-bucket", "path/on/s3", "path/to/dest/file")
-  |> ExAws.request! #=> {:on, :done}
+  |> ExAws.request #=> {:ok, :done}
   ```
 
   ## More high level functionality


### PR DESCRIPTION
If I understand correctly, `ExAws.request!` (with bang) raise an error instead of just returning an ok / error tuple.

See https://github.com/san650/ex_aws/blob/master/lib/ex_aws.ex#L60-L72 