### PR TITLE
Do not repeat file streaming modes as it causes errors in OTP 21.0

### DIFF
--- a/lib/ex_aws/s3/upload.ex
+++ b/lib/ex_aws/s3/upload.ex
@@ -50,8 +50,7 @@ defmodule ExAws.S3.Upload do
   @spec stream_file(path :: binary) :: File.Stream.t
   @spec stream_file(path :: binary, opts :: [chunk_size: pos_integer]) :: File.Stream.t
   def stream_file(path, opts \\ []) do
-    path
-    |> File.stream!([:raw, :read_ahead, :binary], opts[:chunk_size] || 5 * 1024 * 1024)
+    File.stream!(path, [], opts[:chunk_size] || 5 * 1024 * 1024)
   end
 
   @doc """


### PR DESCRIPTION
This bugfix should fix this issue: https://github.com/ex-aws/ex_aws/issues/567

The stream already uses `raw, binary`, and `read_ahead` options, so specifying those modes on stream causes the error on the latest versions of Erlang/Elixir.

**Tested environment**:
* Erlang/OTP 21.0
* Elixir 1.6.6

**Changes**:
* File streaming is not including modes now 