### PR TITLE
Fix/common prefix stream

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -146,7 +146,8 @@ defmodule ExAws.S3 do
     {:marker, binary} |
     {:prefix, binary} |
     {:encoding_type, binary} |
-    {:max_keys, 0..1000}
+    {:max_keys, 0..1000} |
+    {:stream_prefixes, boolean}
   ]
 
   @doc """

--- a/lib/ex_aws/s3/lazy.ex
+++ b/lib/ex_aws/s3/lazy.ex
@@ -1,6 +1,6 @@
 defmodule ExAws.S3.Lazy do
   @moduledoc false
-  ## Implimentation of the lazy functions surfaced by ExAws.S3.Client
+  ## Implementation of the lazy functions surfaced by ExAws.S3.Client
   def stream_objects!(bucket, opts, config) do
     request_fun = fn fun_opts ->
       ExAws.S3.list_objects(bucket, Keyword.merge(opts, fun_opts))
@@ -13,8 +13,14 @@ defmodule ExAws.S3.Lazy do
 
       {fun, args} -> case fun.(args) do
 
+        results = %{contents: [], common_prefixes: prefixes, is_truncated: "true"} ->
+          {prefixes, {fun, [marker: next_marker(results)]}}
+
         results = %{contents: contents, is_truncated: "true"} ->
           {contents, {fun, [marker: next_marker(results)]}}
+
+        %{common_prefixes: prefixes} when prefixes != [] ->
+          {prefixes, :quit}
 
         %{contents: contents} ->
           {contents, :quit}


### PR DESCRIPTION
Previously, fetching common_prefixes would return an empty list as the
contents are empty:

    ExAws.S3.list_objects(bucket, delimeter: "/", prefix: "foo/")
    |> ExAws.stream!()
    |> Enum.map(&(&1))

This tracks both common_prefixes and contents, merging the results into a single
list.

The output will look something like:

```
[
  %{prefix: "/uploads/3bbd4ccd-97aa-4816-b1c2-6c6edaea0de6/"},
  %{prefix: "/uploads/eb6a43b2-dbcd-4154-9622-cf423b4a9d79/"},
  %{
    e_tag: "\"9eafad99c6bb8abc9ac60d7ff9f8f7b7\"",
    key: "/uploads/VERSION",
    last_modified: "2018-07-05T17:00:41.458Z",
    owner: %{
      display_name: "",
      id: "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
    },
    size: "6",
    storage_class: "STANDARD"
  }
]
```
