### PR TITLE
Add object tagging functions: get, put, delete

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -549,6 +549,42 @@ defmodule ExAws.S3 do
     request(:get, bucket, object, resource: "torrent")
   end
 
+  @doc "Get object tags"
+  @spec get_object_tagging(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t
+  def get_object_tagging(bucket, object) do
+    request(:get, bucket, object, [resource: "tagging"], %{parser: &Parsers.parse_tags/1})
+  end
+
+  @doc "Set object tags"
+  @spec put_object_tagging(bucket :: binary, object :: binary, tags :: map) :: ExAws.Operation.S3.t
+  def put_object_tagging(bucket, object, tags) do
+    xml_tags =
+      tags
+      |> Enum.map(fn {key, value} -> [
+        "<Tag>",
+          "<Key>#{key}</Key>",
+          "<Value>#{value}</Value>",
+        "</Tag>"
+      ] end)
+
+    body = [
+      "<Tagging>",
+        "<TagSet>",
+          xml_tags,
+        "</TagSet>",
+      "</Tagging>"
+    ]
+    |> IO.iodata_to_binary()
+
+    request(:put, bucket, object, resource: "tagging", body: body)
+  end
+
+  @doc "Delete object tags"
+  @spec delete_object_tagging(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t
+  def delete_object_tagging(bucket, object) do
+    request(:delete, bucket, object, resource: "tagging")
+  end
+
   @type head_object_opt ::
     {:encryption, customer_encryption_opts}
     | {:range, binary}

--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -96,6 +96,20 @@ if Code.ensure_loaded?(SweetXml) do
 
     def parse_list_parts(val), do: val
 
+    def parse_tags({:ok, %{body: xml} = resp}) do
+      tags =
+        xml
+        |> SweetXml.xpath(~x"//Tagging/TagSet/Tag"l)
+        |> Enum.map(fn node ->
+          key = SweetXml.xpath(node, ~x"./Key/text()"s)
+          value = SweetXml.xpath(node, ~x"./Value/text()"s)
+          {key, value}
+        end)
+        |> Enum.into(%{})
+
+      {:ok, %{resp | body: tags}}
+    end
+
   end
 else
   defmodule ExAws.S3.Parsers do
@@ -108,6 +122,7 @@ else
     def parse_complete_multipart_upload(_val), do: missing_xml_parser()
     def parse_list_multipart_uploads(_val), do: missing_xml_parser()
     def parse_list_parts(_val), do: missing_xml_parser()
+    def parse_tags(_val), do: missing_xml_parser()
   end
 
 end

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -97,4 +97,25 @@ defmodule ExAws.S3.ParserTest do
     assert "abcd" == key
     assert "bUCMhxUCGCA0GiTAhTj6cq2rChItfIMYBgO7To9yiuUyDk4CWqhtHPx8cGkgjzyavE2aW6HvhQgu9pvDB3.oX73RC7N3zM9dSU3mecTndVRHQLJCAsySsT6lXRd2Id2a" == upload_id
   end
+
+  test "#parse_tags parses response" do
+    response = """
+    <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <TagSet>
+          <Tag>
+            <Key>tag1</Key>
+            <Value>val1</Value>
+          </Tag>
+          <Tag>
+            <Key>tag2</Key>
+            <Value>val2</Value>
+          </Tag>
+      </TagSet>
+    </Tagging>
+    """
+    expected_result = {:ok, %{body: %{"tag1" => "val1", "tag2" => "val2"}}}
+
+    result = ExAws.S3.Parsers.parse_tags({:ok, %{body: response}})
+    assert expected_result == result
+  end
 end


### PR DESCRIPTION
The API is pretty simple, you pass a **Map** which is your **TagSet** to `put_object_tagging/3` to set tags.
If you need to update an object tags, you have to first retrieve the **Map** using `get_object_tagging/2` (which parses the body and converts it to a **Map**), update it then use `put_object_tagging/3`.