### PR TITLE
Make the usage of delete_all_objects clearer

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -421,13 +421,19 @@ defmodule ExAws.S3 do
   requests deleting 1000 objects at a time until all are deleted.
 
   Can be streamed.
+  
+  ## Example
+  ```
+  stream = ExAws.S3.list_objects(bucket(), prefix: "some/prefix") |> ExAws.stream!() |> Stream.map(& &1.key)
+  ExAws.S3.delete_all_objects(bucket(), stream) |> ExAws.request() 
+  ```
   """
   @spec delete_all_objects(
     bucket  :: binary,
-    objects :: [binary | {binary, binary}, ...]):: ExAws.Operation.S3DeleteAllObjects.t
+    objects :: [binary | {binary, binary}, ...] | Enum.t):: ExAws.Operation.S3DeleteAllObjects.t
   @spec delete_all_objects(
     bucket  :: binary,
-    objects :: [binary | {binary, binary}, ...], opts :: [quiet: true]):: ExAws.Operation.S3DeleteAllObjects.t
+    objects :: [binary | {binary, binary}, ...] | Enum.t, opts :: [quiet: true]):: ExAws.Operation.S3DeleteAllObjects.t
   def delete_all_objects(bucket, objects, opts \\ []) do
     %ExAws.Operation.S3DeleteAllObjects{bucket: bucket, objects: objects, opts: opts}
   end


### PR DESCRIPTION
Using `delete_all_objects` to delete a large number of objects (like a folder with millions objects) is an important use case and probably the reason this function exists, though it's not clear how it can be used this way - I had to try it just cause it would make sense (and it worked, which is awesome :)). 

So here I want to make it clearer that delete_all_objects not only accepts the list of binary object IDs but can also work with a stream. 

As for spec adjustment, I can also imagine creating a custom type and using it here, something like `@type objects :: [binary | {binary, binary}, ...] | Enum.t`, important part is: this function does not strictly require a list of binaries.