### PR TITLE
Disable Documentation for S3DeleteAllObjects

### DIFF
--- a/lib/ex_aws/s3/delete_all_objects.ex
+++ b/lib/ex_aws/s3/delete_all_objects.ex
@@ -1,4 +1,6 @@
 defmodule ExAws.Operation.S3DeleteAllObjects do
+  @moduledoc false
+  
   defstruct [
     bucket: nil,
     objects: [],


### PR DESCRIPTION
The hexdocs page for [`ExAws.Operation.S3DeleteAllObjects`](https://hexdocs.pm/ex_aws_s3/ExAws.Operation.S3DeleteAllObjects.html) seems completely unnecessary, and I believe its better to disable the `moduledoc` for it.