### PR TITLE
Allow specifying headers on presigned_url.

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -879,12 +879,13 @@ defmodule ExAws.S3 do
     expires_in = Keyword.get(opts, :expires_in, 3600)
     virtual_host = Keyword.get(opts, :virtual_host, false)
     query_params = Keyword.get(opts, :query_params, [])
+    headers = Keyword.get(opts, :headers, [])
     case expires_in > @one_week do
       true -> {:error, "expires_in_exceeds_one_week"}
       false ->
         url = url_to_sign(bucket, object, config, virtual_host)
         datetime = :calendar.universal_time
-        ExAws.Auth.presigned_url(http_method, url, :s3, datetime, config, expires_in, query_params)
+        ExAws.Auth.presigned_url(http_method, url, :s3, datetime, config, expires_in, query_params, nil, headers)
     end
   end
 


### PR DESCRIPTION
Addresses ex-aws/ex_aws_s3#36, see my comments on ex-aws/ex-aws#540 for the rationale. Requires https://github.com/ex-aws/ex_aws/pull/593 to be merged first.