### PR TITLE
Add sign headers to presigned_url

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -84,6 +84,7 @@ defmodule ExAws.S3 do
       {:expires_in, integer}
     | {:virtual_host, boolean}
     | {:query_params, [{binary, binary}]}
+    | {:sign_headers, [{binary, binary}]}
   ]
 
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]
@@ -421,11 +422,11 @@ defmodule ExAws.S3 do
   requests deleting 1000 objects at a time until all are deleted.
 
   Can be streamed.
-  
+
   ## Example
   ```
   stream = ExAws.S3.list_objects(bucket(), prefix: "some/prefix") |> ExAws.stream!() |> Stream.map(& &1.key)
-  ExAws.S3.delete_all_objects(bucket(), stream) |> ExAws.request() 
+  ExAws.S3.delete_all_objects(bucket(), stream) |> ExAws.request()
   ```
   """
   @spec delete_all_objects(
@@ -879,12 +880,13 @@ defmodule ExAws.S3 do
     expires_in = Keyword.get(opts, :expires_in, 3600)
     virtual_host = Keyword.get(opts, :virtual_host, false)
     query_params = Keyword.get(opts, :query_params, [])
+    sign_headers = Keyword.get(opts, :sign_headers, [])
     case expires_in > @one_week do
       true -> {:error, "expires_in_exceeds_one_week"}
       false ->
         url = url_to_sign(bucket, object, config, virtual_host)
         datetime = :calendar.universal_time
-        ExAws.Auth.presigned_url(http_method, url, :s3, datetime, config, expires_in, query_params)
+        ExAws.Auth.presigned_url(http_method, url, :s3, datetime, config, expires_in, query_params, sign_headers)
     end
   end
 


### PR DESCRIPTION
Issue: https://github.com/ex-aws/ex_aws/issues/602

Accept `sign_headers` in addition to `query_params` to allow for query params that will not also be sent in the headers of the request.