### PR TITLE
Add ability to stream download files directly into memory

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -428,11 +428,11 @@ defmodule ExAws.S3 do
   requests deleting 1000 objects at a time until all are deleted.
 
   Can be streamed.
-  
+
   ## Example
   ```
   stream = ExAws.S3.list_objects(bucket(), prefix: "some/prefix") |> ExAws.stream!() |> Stream.map(& &1.key)
-  ExAws.S3.delete_all_objects(bucket(), stream) |> ExAws.request() 
+  ExAws.S3.delete_all_objects(bucket(), stream) |> ExAws.request()
   ```
   """
   @spec delete_all_objects(
@@ -494,8 +494,8 @@ defmodule ExAws.S3 do
 
   Defaults to a concurrency of 8, chunk size of 1MB, and a timeout of 1 minute.
   """
-  @spec download_file(bucket :: binary, path :: binary, dest :: binary) :: __MODULE__.Download.t
-  @spec download_file(bucket :: binary, path :: binary, dest :: binary, opts :: download_file_opts) :: __MODULE__.Download.t
+  @spec download_file(bucket :: binary, path :: binary, dest :: :memory | binary) :: __MODULE__.Download.t
+  @spec download_file(bucket :: binary, path :: binary, dest :: :memory | binary, opts :: download_file_opts) :: __MODULE__.Download.t
   def download_file(bucket, path, dest, opts \\ []) do
     %__MODULE__.Download{
       bucket: bucket,

--- a/lib/ex_aws/s3/download.ex
+++ b/lib/ex_aws/s3/download.ex
@@ -92,7 +92,20 @@ defimpl ExAws.Operation, for: ExAws.S3.Download do
     end
   end
 
-  def stream!(_op, _config) do
-    raise "not supported yet"
+  def stream!(op, config) do
+    op
+    |> Download.build_chunk_stream(config)
+    |> Task.async_stream(fn boundaries ->
+      Download.get_chunk(op, boundaries, config)
+    end,
+      max_concurrency: Keyword.get(op.opts, :max_concurrency, 8),
+      timeout: Keyword.get(op.opts, :timeout, 60_000)
+    )
+    |> Stream.map(fn
+      # Download.get_chunk/3 uses ExAws.request! so if we get here it is
+      # successful otherwise it has already risen an error
+      {:ok, {_start_byte, chunk}} ->
+        chunk
+    end)
   end
 end


### PR DESCRIPTION
Add the ability to stream file contents directly to memory for performance reasons.

I need to add a test, but this I tested it manually and its working fine.