### PR TITLE
Include :version_id option in typespec for head_object/3

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -574,6 +574,7 @@ defmodule ExAws.S3 do
   @type head_object_opt ::
     {:encryption, customer_encryption_opts}
     | {:range, binary}
+    | {:version_id, binary}
     | {:if_modified_since, binary}
     | {:if_unmodified_since, binary}
     | {:if_match, binary}


### PR DESCRIPTION
`:version_id` option key is used in the function body, but is not declared in the typespec. This leads to Dialyzer errors in any project that uses S3 and calls the funciton with this (valid) option. This PR fixes this by adding a `:version_id` option to the typespec.