### PR TITLE
Fix typespecs on put_bucket_cors/2

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -293,7 +293,7 @@ defmodule ExAws.S3 do
   end
 
   @doc "Update or create a bucket CORS policy"
-  @spec put_bucket_cors(bucket :: binary, cors_config :: map()) :: ExAws.Operation.S3.t
+  @spec put_bucket_cors(bucket :: binary, cors_config :: list(map())) :: ExAws.Operation.S3.t
   def put_bucket_cors(bucket, cors_rules) do
     rules = cors_rules
     |> Enum.map(&build_cors_rule/1)


### PR DESCRIPTION
Hi there.

I got the following error on `ExAws.S3.put_bucket_cors/2` when using map in second argument.

```
** (BadMapError) expected a map, got: {:allowed_headers, ["*"]}
    (elixir) lib/map.ex:451: Map.get({:allowed_headers, ["*"]}, :allowed_origins, [])
    (ex_aws_s3) lib/ex_aws/s3/utils.ex:100: anonymous fn/2 in ExAws.S3.Utils.build_cors_rule/1
    (elixir) lib/enum.ex:2994: Enum.flat_map_list/2
    (ex_aws_s3) lib/ex_aws/s3/utils.ex:98: ExAws.S3.Utils.build_cors_rule/1
    (elixir) lib/enum.ex:1340: anonymous fn/3 in Enum.map/2
    (stdlib) maps.erl:232: :maps.fold_1/3
    (elixir) lib/enum.ex:1964: Enum.map/2
    (ex_aws_s3) lib/ex_aws/s3.ex:299: ExAws.S3.put_bucket_cors/2
```

But, when I use list of map, got a warning on dialyzer.

```
$ mix dialyzer
...
The function call will not succeed.

ExAws.S3.put_bucket_cors(_bucket_name :: binary(), [
  %{
    :allowed_headers => [any(), ...],
    :allowed_methods => [any(), ...],
    :allowed_origins => [any(), ...],
    :max_age_seconds => 3000
  },
  ...
])
```

Please review when you have time 😄 