### PR TITLE
Ensure src_object is encoded for put_copy_object/5

### DIFF
--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -183,13 +183,25 @@ defmodule ExAws.S3Test do
   test "#put_object_copy utf8" do
     expected = %Operation.S3{
       bucket: "dest-bucket",
-      headers: %{"x-amz-copy-source" => "/src-bucket//foo/%C3%BC.txt"},
+      headers: %{"x-amz-copy-source" => "/src-bucket/foo/%C3%BC.txt"},
       path: "dest-object",
       http_method: :put
     }
 
     assert expected ==
              S3.put_object_copy("dest-bucket", "dest-object", "src-bucket", "/foo/ü.txt")
+  end
+
+  test "#put_object_copy encoding" do
+    expected = %Operation.S3{
+      bucket: "dest-bucket",
+      headers: %{"x-amz-copy-source" => "/src-bucket/foo/hello%2Bfriend.txt"},
+      path: "dest-object",
+      http_method: :put
+    }
+
+    assert expected ==
+             S3.put_object_copy("dest-bucket", "dest-object", "src-bucket", "/foo/hello+friend.txt")
   end
 
   test "#complete_multipart_upload" do


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/ex-aws/ex_aws_s3/issues/77, where objects that have a `+` in the name aren't being escaped properly

It also requires PR https://github.com/ex-aws/ex_aws/pull/648 in the ex_aws repo as well