### PR TITLE
Add versionId for get_object

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -663,10 +663,7 @@ defmodule ExAws.S3 do
     |> build_encryption_headers
     |> Map.merge(headers)
 
-    params = case Map.fetch(opts, :version_id) do
-      {:ok, id} -> %{"versionId" => id}
-      _ -> %{}
-    end
+    params = format_and_take(opts, [:version_id])
     request(:head, bucket, object, headers: headers, params: params)
   end
 
@@ -702,10 +699,7 @@ defmodule ExAws.S3 do
     number_of_days :: pos_integer,
     opts           :: [version_id: binary]) :: ExAws.Operation.S3.t
   def post_object_restore(bucket, object, number_of_days, opts \\ []) do
-    params = case Keyword.fetch(opts, :version_id) do
-      {:ok, id} -> %{"versionId" => id}
-      _ -> %{}
-    end
+    params = format_and_take(opts, [:version_id])
 
     body = """
     <RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-3-01">

--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -111,6 +111,7 @@ defmodule ExAws.S3.Utils do
     |> IO.iodata_to_binary
   end
 
+  def normalize_param(:version_id), do: "versionId"
   def normalize_param(param) when is_atom(param) do
     param
     |> Atom.to_string

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -53,7 +53,10 @@ defmodule ExAws.S3Test do
     expected = %Operation.S3{
       bucket: "bucket",
       headers: %{"x-amz-server-side-encryption-customer-algorithm" => "md5"},
-      params: %{"response-content-type" => "application/json"},
+      params: %{
+        "response-content-type" => "application/json",
+        "versionId" => "g6qNRfGox7jrBvrs9x28soa0JdEaRwAN"
+      },
       path: "object.json",
       http_method: :get
     }
@@ -63,7 +66,8 @@ defmodule ExAws.S3Test do
                "bucket",
                "object.json",
                response: [content_type: "application/json"],
-               encryption: [customer_algorithm: "md5"]
+               encryption: [customer_algorithm: "md5"],
+               version_id: "g6qNRfGox7jrBvrs9x28soa0JdEaRwAN"
              )
   end
 


### PR DESCRIPTION
What?  
This PR adds the ability to fetch specific versions of object by adding a new `version_id` option to `S3.get_object/2`.

Why?
`ex_aws_s3` already allows you to list versions of an object with `S3.get_bucket_object_versions/1`, but there was no way to go and fetch objects based on a specific version.

What Else?
The parameter for the version id is `versionId`, which is `camelCase`.  It seems that most of the other parameters are `kebab-case`.  I found two other instances in the code where the `camelCase` key was being manually created, and switched them to also use the utility function.  If we liked it better the other way, let me know and I'll switch `get_object ` to do the same thing.