### PR TITLE
Updates ExAws.S3.Upload operation to accept binary data

### DIFF
--- a/test/lib/s3/upload_test.exs
+++ b/test/lib/s3/upload_test.exs
@@ -7,6 +7,23 @@ defmodule ExAws.S3.UploadTest do
   describe "integration test" do
     setup [:start_bypass]
 
+    test "uploading a binary from memory with a stream", %{bypass: bypass} do
+      file_path = __ENV__.file
+
+      setup_multipart_upload_backend(bypass, self(), "my-bucket", "test.txt")
+
+      {:ok, _} =
+        file_path
+        |> File.read!()
+        |> S3.Upload.stream_bytes()
+        |> S3.upload("my-bucket", "test.txt")
+        |> ExAws.request(exaws_config_for_bypass(bypass))
+
+      assert_received :initiated_upload
+      assert_received :chunk_uploaded
+      assert_received :completed_upload
+    end
+
     test "uploading a file with a stream", %{bypass: bypass} do
       file_path = __ENV__.file
 


### PR DESCRIPTION
What?
This PR adds a new function to `ExAws.S3.Upload` called `stream_bytes` that accepts a binary file data, converts it to a list and then chunks it by a specified chunk size or the default (5 Mb).

Why?
Currently the library only supports Stream multi-part uploads given a File.Stream. Sometimes it's useful to be able to upload from memory (such as when you already download a file from a different source and you want to just stream upload it to S3 instead of saving it to disk first). 

This works because `Stream.with_index(1)` will convert this to the right input to  `upload_chunk!`. The last change is to convert the chunks from a list back to binary because `ExAws` S3 implementation expects it to be binary.