### PR TITLE
Implement put_bucket_livecycle

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -362,11 +362,67 @@ defmodule ExAws.S3 do
             resource: "cors", body: body, headers: headers)
   end
 
-  @doc "Update or create a bucket lifecycle configuration"
-  @spec put_bucket_lifecycle(bucket :: binary, lifecycle_config :: map()) :: no_return
-  def put_bucket_lifecycle(bucket, _livecycle_config) do
-    raise "not yet implemented"
-    request(:put, bucket, "/")
+
+  @doc """
+  Update or create a bucket lifecycle configuration
+
+  ## Live-Cycle Rule Format
+
+      %{
+        # Unique id for the rule (max. 255 chars, max. 1000 rules allowed)
+        id: "123",
+
+        # Disabled rules are not executed
+        enabled: true,
+
+        # Filters
+        # Can be based on prefix, object tag(s), both or none
+        filter: %{
+          prefix: "prefix/",
+          tags: %{
+            "key" => "value"
+          }
+        },
+
+        # Actions
+        # https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions
+        actions: %{
+          transition: %{
+            trigger: {:date, ~D[2020-03-26]}, # Date or days based
+            storage: ""
+          },
+          expiration: %{
+            trigger: {:days, 2}, # Date or days based
+            expired_object_delete_marker: true
+          },
+          noncurrent_version_transition: %{
+            trigger: {:days, 2}, # Only days based
+            storage: ""
+          },
+          noncurrent_version_expiration: %{
+            trigger: {:days, 2} # Only days based
+          },
+          abort_incomplete_multipart_upload: %{
+            trigger: {:days, 2} # Only days based
+          }
+        }
+      }
+
+  """
+  @spec put_bucket_lifecycle(bucket :: binary, lifecycle_rules :: list(map())) ::
+          ExAws.Operation.S3.t()
+  def put_bucket_lifecycle(bucket, lifecycle_rules) do
+    rules =
+      lifecycle_rules
+      |> Enum.map(&build_lifecycle_rule/1)
+      |> IO.iodata_to_binary()
+
+    body = "<LifecycleConfiguration>#{rules}</LifecycleConfiguration>"
+
+    content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
+    headers = %{"content-md5" => content_md5}
+
+    request(:put, bucket, "/", resource: "lifecycle", body: body, headers: headers)
   end
 
   @doc "Update or create a bucket policy configuration"

--- a/test/lib/s3/utils_test.exs
+++ b/test/lib/s3/utils_test.exs
@@ -27,4 +27,38 @@ defmodule ExAws.S3.ImplTest do
     assert Utils.build_encryption_headers([aws_kms_key_id: "key_id"]) ==
     %{"x-amz-server-side-encryption" => "aws:kms", "x-amz-server-side-encryption-aws-kms-key-id" => "key_id"}
   end
+
+  test "build_lifecycle_rule" do
+    rule = %{
+      id: "123",
+      enabled: true,
+      filter: %{
+        prefix: "prefix/",
+        tags: %{}
+      },
+      actions: %{
+        transition: %{
+          trigger: {:days, 2},
+          storage: ""
+        },
+        expiration: %{
+          trigger: {:days, 2},
+          expired_object_delete_marker: true
+        },
+        noncurrent_version_transition: %{
+          trigger: {:days, 2},
+          storage: ""
+        },
+        noncurrent_version_expiration: %{
+          trigger: {:days, 2}
+        },
+        abort_incomplete_multipart_upload: %{
+          trigger: {:days, 2}
+        }
+      }
+    }
+
+    assert rule |> Utils.build_lifecycle_rule() ==
+             "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><NoncurrentVersionExpiration><NoncurrentDays>2</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>2</NoncurrentDays><StorageClass></StorageClass></NoncurrentVersionTransition><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+  end
 end


### PR DESCRIPTION
Tech. this is an implementation of:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html

and not of the deprecated:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html

So I'm not sure if the naming in ex_aws_s3 should be updated as well? To make matters worse `GetBucketLifecycle` has a new API counterpart in the docs as well, but the endpoint is the same, so this seems to have been done using a breaking change, and `DeleteBucketLifecycle` didn't get a new API counterpart.