### PR TITLE
Make Optional sweet_xml Dependency More Obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Service module for https://github.com/ex-aws/ex_aws
 ## Installation
 
 The package can be installed by adding `ex_aws_s3` to your list of dependencies in `mix.exs`
-along with `:ex_aws` and your preferred JSON codec / http client
+along with `:ex_aws`, your preferred JSON codec / http client, and optionally `sweet_xml`
+to support operations like `list_objects` that require XML parsing.
 
 ```elixir
 def deps do
@@ -14,6 +15,7 @@ def deps do
     {:ex_aws_s3, "~> 2.0"},
     {:poison, "~> 3.0"},
     {:hackney, "~> 1.9"},
+    {:sweet_xml, "~> 0.6.6"}, # optional dependency
   ]
 end
 ```


### PR DESCRIPTION
Some operations require XML parsing. When trying to call those functions (like `ExAws.S3.list_objects`) without `sweet_xml` as a dependency the app will report an error "Missing XML parser. Please see docs".

This change makes the dependency more obvious in the docs.

Primarily requesting this change because I was running into that error, was a bit confused, and only really understood the warning properly after I looked at the code and also saw https://github.com/ex-aws/ex_aws_s3/issues/32