### PR TITLE
Upload.perform/2: Remove redundant Enum.to_list/1 call

### DIFF
--- a/lib/ex_aws/s3/upload.ex
+++ b/lib/ex_aws/s3/upload.ex
@@ -96,7 +96,6 @@ defimpl ExAws.Operation, for: ExAws.S3.Upload do
         max_concurrency: Keyword.get(op.opts, :max_concurrency, 4),
         timeout: Keyword.get(op.opts, :timeout, 30_000)
       )
-      |> Enum.to_list
       |> Enum.map(fn {:ok, val} -> val end)
       |> Upload.complete(op, config)
     end


### PR DESCRIPTION
The call to `Enum.map/2` below will execute the stream and will avoid an extra list traversal.