### PR TITLE
Escape XML keys in delete_multiple_objects/3

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -474,10 +474,10 @@ defmodule ExAws.S3 do
     objects_xml =
       Enum.map(objects, fn
         {key, version} ->
-          ["<Object><Key>", key, "</Key><VersionId>", version, "</VersionId></Object>"]
+          ["<Object><Key>", escape_xml_string(key), "</Key><VersionId>", version, "</VersionId></Object>"]
 
         key ->
-          ["<Object><Key>", key, "</Key></Object>"]
+          ["<Object><Key>", escape_xml_string(key), "</Key></Object>"]
       end)
 
     quiet =
@@ -1242,5 +1242,17 @@ defmodule ExAws.S3 do
 
   defp put_accelerate_host(config) do
     Map.put(config, :host, "s3-accelerate.amazonaws.com")
+  end
+
+  defp escape_xml_string(value) do
+    String.replace(value, ["'", "\"", "&", "<", ">", "\r", "\n"], fn
+      "'" -> "&apos;"
+      "\"" -> "&quot;"
+      "&" -> "&amp;"
+      "<" -> "&lt;"
+      ">" -> "&gt;"
+      "\r" -> "&#13;"
+      "\n" -> "&#10;"
+    end)
   end
 end

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -260,14 +260,14 @@ defmodule ExAws.S3Test do
   test "#delete_multiple_objects" do
     expected = %Operation.S3{
       body:
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Delete><Object><Key>foo</Key></Object><Object><Key>bar</Key><VersionId>v1</VersionId></Object></Delete>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Delete><Object><Key>foo</Key></Object><Object><Key>bar</Key><VersionId>v1</VersionId></Object><Object><Key>special characters: &apos;&quot;&amp;&lt;&gt;&#13;&#10;</Key></Object></Delete>",
       bucket: "bucket",
       path: "/?delete",
-      headers: %{"content-md5" => "lvfX5nHeLllWDA7QnpsnrA=="},
+      headers: %{"content-md5" => "G9Pq8w8AQUesREJndxKbKw=="},
       http_method: :post
     }
 
-    assert expected == S3.delete_multiple_objects("bucket", ["foo", {"bar", "v1"}])
+    assert expected == S3.delete_multiple_objects("bucket", ["foo", {"bar", "v1"}, "special characters: '\"&<>\r\n"])
   end
 
   test "#post_object_restore" do


### PR DESCRIPTION
Object keys in `delete_multiple_objects/3` were being used exactly as passed. However, [AWS provides a list of special characters that need to be escaped](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).

Fixes #85. 