### PR TITLE
Add version_id options to delete_object function.

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -110,13 +110,13 @@ defmodule ExAws.S3 do
 
   @doc """
   List objects in bucket
-
+  
   Can be streamed.
-
+  
   ## Examples
   ```
   S3.list_objects("my-bucket") |> ExAws.request
-
+  
   S3.list_objects("my-bucket") |> ExAws.stream!
   S3.list_objects("my-bucket", delimiter: "/", prefix: "backup") |> ExAws.stream!
   S3.list_objects("my-bucket", prefix: "some/inner/location/path") |> ExAws.stream!
@@ -150,13 +150,13 @@ defmodule ExAws.S3 do
 
   @doc """
   List objects in bucket
-
+  
   Can be streamed.
-
+  
   ## Examples
   ```
   S3.list_objects_v2("my-bucket") |> ExAws.request
-
+  
   S3.list_objects_v2("my-bucket") |> ExAws.stream!
   S3.list_objects_v2("my-bucket", delimiter: "/", prefix: "backup") |> ExAws.stream!
   S3.list_objects_v2("my-bucket", prefix: "some/inner/location/path") |> ExAws.stream!
@@ -325,16 +325,16 @@ defmodule ExAws.S3 do
 
   @doc """
   Update or create a bucket lifecycle configuration
-
+  
   ## Live-Cycle Rule Format
-
+  
       %{
         # Unique id for the rule (max. 255 chars, max. 1000 rules allowed)
         id: "123",
-
+  
         # Disabled rules are not executed
         enabled: true,
-
+  
         # Filters
         # Can be based on prefix, object tag(s), both or none
         filter: %{
@@ -343,7 +343,7 @@ defmodule ExAws.S3 do
             "key" => "value"
           }
         },
-
+  
         # Actions
         # https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions
         actions: %{
@@ -367,7 +367,7 @@ defmodule ExAws.S3 do
           }
         }
       }
-
+  
   """
   @spec put_bucket_lifecycle(bucket :: binary, lifecycle_rules :: list(map())) ::
           ExAws.Operation.S3.t()
@@ -429,7 +429,7 @@ defmodule ExAws.S3 do
 
   @doc """
   Update or create a bucket versioning configuration
-
+  
   ## Example
   ```
   ExAws.S3.put_bucket_versioning(
@@ -465,9 +465,15 @@ defmodule ExAws.S3 do
           | {:x_amz_expected_bucket_owner, binary}
           | {:version_id, binary}
   @type delete_object_opts :: [delete_object_opt]
-  @spec delete_object(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t
-  @spec delete_object(bucket :: binary, object :: binary, opts :: delete_object_opts) :: ExAws.Operation.S3.t
-  @request_headers [:x_amz_mfa, :x_amz_request_payer, :x_amz_bypass_governance_retention, :x_amz_expected_bucket_owner]
+  @spec delete_object(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t()
+  @spec delete_object(bucket :: binary, object :: binary, opts :: delete_object_opts) ::
+          ExAws.Operation.S3.t()
+  @request_headers [
+    :x_amz_mfa,
+    :x_amz_request_payer,
+    :x_amz_bypass_governance_retention,
+    :x_amz_expected_bucket_owner
+  ]
   def delete_object(bucket, object, opts \\ []) do
     opts = opts |> Map.new()
 
@@ -491,7 +497,7 @@ defmodule ExAws.S3 do
 
   @doc """
   Delete multiple objects within a bucket
-
+  
   Limited to 1000 objects.
   """
   @spec delete_multiple_objects(
@@ -541,12 +547,12 @@ defmodule ExAws.S3 do
 
   @doc """
   Delete all listed objects.
-
+  
   When performed, this function will continue making `delete_multiple_objects`
   requests deleting 1000 objects at a time until all are deleted.
-
+  
   Can be streamed.
-
+  
   ## Example
   ```
   stream = ExAws.S3.list_objects(bucket(), prefix: "some/prefix") |> ExAws.stream!() |> Stream.map(& &1.key)
@@ -580,7 +586,7 @@ defmodule ExAws.S3 do
         ]
   @doc """
   Get an object from a bucket
-
+  
   ## Examples
   ```
   S3.get_object("my-bucket", "image.png")
@@ -634,26 +640,26 @@ defmodule ExAws.S3 do
 
   @doc """
   Download an S3 object to a file.
-
+  
   This operation downloads multiple parts of an S3 object concurrently, allowing
   you to maximize throughput.
-
+  
   Defaults to a concurrency of 8, chunk size of 1MB, and a timeout of 1 minute.
-
+  
   ### Streaming to memory
-
+  
   In order to use `ExAws.stream!/2`, the third `dest` parameter must be set to `:memory`.
   An example would be like the following:
-
+  
       ExAws.S3.download_file("example-bucket", "path/to/file.txt", :memory)
       |> ExAws.stream!()
-
+  
   Note that **this won't start fetching anything immediately** since it returns an Elixir `Stream`.
-
+  
   #### Streaming by line
-
+  
   Streaming by line can be done with `Stream.chunk_while/4`. Here is an example:
-
+  
       # Returns a stream which grabs chunks of data from S3 as specified in `opts`
       # but processes the stream line by line. For example, the default chunk
       # size of 1MB means requests for bytes from S3 will ask for 1MB sizes (to be downloaded)
@@ -666,11 +672,11 @@ defmodule ExAws.S3 do
         # |> StreamGzip.gunzip()
         |> Stream.chunk_while("", &chunk_fun/2, &after_fun/1)
       end
-
+  
       def chunk_fun(chunk, acc) do
         split_chunk(acc, chunk) || split_chunk(chunk, "")
       end
-
+  
       defp split_chunk("", _append_remaining), do: nil
       defp split_chunk(string, append_remaining) do
         case String.split(string, "\\n", parts: 2) do
@@ -680,7 +686,7 @@ defmodule ExAws.S3 do
             {:cont, l, remaining <> append_remaining}
         end
       end
-
+  
       def after_fun(""), do: {:cont, ""}
       def after_fun(acc), do: {:cont, acc, ""}
   """
@@ -706,11 +712,11 @@ defmodule ExAws.S3 do
 
   @doc """
   Multipart upload to S3.
-
+  
   Handles initialization, uploading parts concurrently, and multipart upload completion.
-
+  
   ## Uploading a stream
-
+  
   Streams that emit binaries may be uploaded directly to S3. Each binary will be uploaded
   as a chunk, so it must be at least 5 megabytes in size. The `S3.Upload.stream_file`
   helper takes care of reading the file in 5 megabyte chunks.
@@ -720,17 +726,17 @@ defmodule ExAws.S3 do
   |> S3.upload("my-bucket", "path/on/s3")
   |> ExAws.request! #=> :done
   ```
-
+  
   ## Options
-
+  
   These options are specific to this function
   * See `Task.async_stream/5`'s `:max_concurrency` and `:timeout` options.
     * `:max_concurrency` - only applies when uploading a stream. Sets the maximum number of tasks to run at the same time. Defaults to `4`
     * `:timeout` - the maximum amount of time (in milliseconds) each task is allowed to execute for. Defaults to `30_000`.
-
+  
   All other options (ex. `:content_type`) are passed through to
   `ExAws.S3.initiate_multipart_upload/3`.
-
+  
   """
   @spec upload(
           source :: Enumerable.t(),
@@ -882,11 +888,11 @@ defmodule ExAws.S3 do
 
   @doc """
   Add a set of tags to an existing object
-
+  
   ## Options
-
+  
   - `:version_id` - The versionId of the object that the tag-set will be added to.
-
+  
   """
   @spec put_object_tagging(
           bucket :: binary,
@@ -1191,17 +1197,17 @@ defmodule ExAws.S3 do
 
   @doc """
   Generate a pre-signed URL for an object.
-
+  
   When option param `:virtual_host` is `true`, the bucket name will be used as
   the hostname. This will cause the returned URL to be 'http' and not 'https'.
-
+  
   When option param `:s3_accelerate` is `true`, the bucket name will be used as
   the hostname, along with the `s3-accelerate.amazonaws.com` host.
-
+  
   Additional (signed) query parameters can be added to the url by setting option param
   `:query_params` to a list of `{"key", "value"}` pairs. Useful if you are uploading parts of
   a multipart upload directly from the browser.
-
+  
   Signed headers can be added to the url by setting option param `:headers` to
   a list of `{"key", "value"}` pairs.
   """

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -458,9 +458,28 @@ defmodule ExAws.S3 do
   ###########
 
   @doc "Delete an object within a bucket"
-  @spec delete_object(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t()
+  @type delete_object_opt ::
+          {:x_amz_mfa, binary}
+          | {:x_amz_request_payer, binary}
+          | {:x_amz_bypass_governance_retention, binary}
+          | {:x_amz_expected_bucket_owner, binary}
+          | {:version_id, binary}
+  @type delete_object_opts :: [delete_object_opt]
+  @spec delete_object(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t
+  @spec delete_object(bucket :: binary, object :: binary, opts :: delete_object_opts) :: ExAws.Operation.S3.t
+  @request_headers [:x_amz_mfa, :x_amz_request_payer, :x_amz_bypass_governance_retention, :x_amz_expected_bucket_owner]
   def delete_object(bucket, object, opts \\ []) do
-    request(:delete, bucket, object, headers: opts |> Map.new())
+    opts = opts |> Map.new()
+
+    params =
+      opts
+      |> format_and_take([:version_id])
+
+    headers =
+      opts
+      |> format_and_take(@request_headers)
+
+    request(:delete, bucket, object, headers: headers, params: params)
   end
 
   @doc "Remove the entire tag set from the specified object"

--- a/lib/ex_aws/s3/upload.ex
+++ b/lib/ex_aws/s3/upload.ex
@@ -1,9 +1,9 @@
 defmodule ExAws.S3.Upload do
   @moduledoc """
   Represents an AWS S3 Multipart Upload operation.
-
+  
   Implements `ExAws.Operation.perform/2`
-
+  
   ## Examples
   ```
   "path/to/big/file"
@@ -11,7 +11,7 @@ defmodule ExAws.S3.Upload do
   |> S3.upload("my-bucket", "path/on/s3")
   |> ExAws.request! #=> :done
   ```
-
+  
   See `ExAws.S3.upload/4` for options
   """
 
@@ -62,7 +62,7 @@ defmodule ExAws.S3.Upload do
 
   @doc """
   Open a file stream for use in an upload.
-
+  
   Chunk size must be at least 5 MiB. Defaults to 5 MiB
   """
   @spec stream_file(path :: binary) :: File.Stream.t()
@@ -73,7 +73,7 @@ defmodule ExAws.S3.Upload do
 
   @doc """
   Upload a chunk for an operation.
-
+  
   The first argument is a tuple with the binary contents of the chunk, and a
   positive integer index indicating which chunk it is. It will return this index
   along with the `etag` response from AWS necessary to complete the multipart upload.

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -275,19 +275,24 @@ defmodule ExAws.S3Test do
       bucket: "bucket",
       http_method: :delete,
       params: %{"versionId" => "1234"},
-      headers: %{"x-amz-mfa" => "MFA",
-                  "x-amz-request-payer" => "RequestPayer",
-                  "x-amz-bypass-governance-retention" => "BypassGovernanceRetention",
-                  "x-amz-expected-bucket-owner" => "ExpectedBucketOwner"
-                },
+      headers: %{
+        "x-amz-mfa" => "MFA",
+        "x-amz-request-payer" => "RequestPayer",
+        "x-amz-bypass-governance-retention" => "BypassGovernanceRetention",
+        "x-amz-expected-bucket-owner" => "ExpectedBucketOwner"
+      },
       path: "object",
-      resource: "",
+      resource: ""
     }
 
-    assert expected == S3.delete_object("bucket", "object", version_id: "1234", 
-                                        x_amz_mfa: "MFA", x_amz_request_payer: "RequestPayer",
-                                        x_amz_bypass_governance_retention: "BypassGovernanceRetention",
-                                        x_amz_expected_bucket_owner: "ExpectedBucketOwner")
+    assert expected ==
+             S3.delete_object("bucket", "object",
+               version_id: "1234",
+               x_amz_mfa: "MFA",
+               x_amz_request_payer: "RequestPayer",
+               x_amz_bypass_governance_retention: "BypassGovernanceRetention",
+               x_amz_expected_bucket_owner: "ExpectedBucketOwner"
+             )
   end
 
   test "#delete_multiple_objects" do

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -275,11 +275,19 @@ defmodule ExAws.S3Test do
       bucket: "bucket",
       http_method: :delete,
       params: %{"versionId" => "1234"},
+      headers: %{"x-amz-mfa" => "MFA",
+                  "x-amz-request-payer" => "RequestPayer",
+                  "x-amz-bypass-governance-retention" => "BypassGovernanceRetention",
+                  "x-amz-expected-bucket-owner" => "ExpectedBucketOwner"
+                },
       path: "object",
       resource: "",
     }
 
-    assert expected == S3.delete_object("bucket", "object", version_id: "1234")
+    assert expected == S3.delete_object("bucket", "object", version_id: "1234", 
+                                        x_amz_mfa: "MFA", x_amz_request_payer: "RequestPayer",
+                                        x_amz_bypass_governance_retention: "BypassGovernanceRetention",
+                                        x_amz_expected_bucket_owner: "ExpectedBucketOwner")
   end
 
   test "#delete_multiple_objects" do

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -257,6 +257,31 @@ defmodule ExAws.S3Test do
              )
   end
 
+  test "#delete_object no options" do
+    expected = %Operation.S3{
+      body: "",
+      bucket: "bucket",
+      path: "object",
+      http_method: :delete,
+      resource: ""
+    }
+
+    assert expected == S3.delete_object("bucket", "object")
+  end
+
+  test "#delete_object version_id option" do
+    expected = %Operation.S3{
+      body: "",
+      bucket: "bucket",
+      http_method: :delete,
+      params: %{"versionId" => "1234"},
+      path: "object",
+      resource: "",
+    }
+
+    assert expected == S3.delete_object("bucket", "object", version_id: "1234")
+  end
+
   test "#delete_multiple_objects" do
     expected = %Operation.S3{
       body:

--- a/test/support/file_helpers.ex
+++ b/test/support/file_helpers.ex
@@ -14,7 +14,7 @@ defmodule Support.FileHelpers do
   @doc """
   Executes the given function in a temp directory
   tailored for this test case and test.
-
+  
   Note: It doesn't appear this can be run with `use ExUnit.Case, async: true`
   """
   defmacro in_tmp(fun) do


### PR DESCRIPTION
This PR adds the ability to delete an object version in the S3 versioning enabled storage.

Add `:version_id` option to `delete_object/3` function.
The API Document is [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html). (delete_object)