### PR TITLE
Fix acl processing for presigned post

### DIFF
--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -284,7 +284,7 @@ defmodule ExAws.S3.Utils do
 
   defp acl_condition({:starts_with, starts_with}), do: [["starts-with", "$key", starts_with]]
   defp acl_condition(nil), do: []
-  defp acl_condition(acl) when is_binary(acl), do: %{"acl" => acl}
+  defp acl_condition(acl) when is_binary(acl), do: [%{"acl" => acl}]
 
   defp key_condition({:starts_with, starts_with}), do: [["starts-with", "$key", starts_with]]
   defp key_condition(nil), do: []

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -564,6 +564,7 @@ defmodule ExAws.S3Test do
 
     post_data =
       S3.presigned_post(ExAws.Config.new(:s3), bucket, key,
+        acl: "public-read",
         custom_conditions: [["starts-with", "$Content-Type", "image/"]],
         content_length_range: [10, 20]
       )
@@ -585,6 +586,10 @@ defmodule ExAws.S3Test do
              10,
              20
            ]
+
+    assert Enum.find(conditions, &(is_map(&1) && Map.has_key?(&1, "acl"))) == %{
+             "acl" => "public-read"
+           }
   end
 
   @spec assert_pre_signed_url(


### PR DESCRIPTION
This fixes an error that occurs when an acl condition is passed as an option when generating presigned posts.

Issue: https://github.com/ex-aws/ex_aws_s3/issues/139