### PR TITLE
Support tagging_directive in ExAws.S3.Utils.put_object_headers/1

### DIFF
--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -15,7 +15,7 @@ defmodule ExAws.S3.Utils do
     :expires,
     :content_md5
   ]
-  @amz_headers [:storage_class, :website_redirect_location, :tagging]
+  @amz_headers [:storage_class, :website_redirect_location, :tagging, :tagging_directive]
   def put_object_headers(opts) do
     opts = opts |> Map.new()
 

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -155,7 +155,9 @@ defmodule ExAws.S3Test do
         "x-amz-copy-source" => "/src-bucket/src-object",
         "x-amz-server-side-encryption-customer-algorithm" => "md5",
         "x-amz-copy-source-server-side-encryption-customer-algorithm" => "md5",
-        "x-amz-meta-foo" => "sqiggles"
+        "x-amz-meta-foo" => "sqiggles",
+        "x-amz-tagging" => "foo=foo&bar=bar",
+        "x-amz-tagging-directive" => :REPLACE
       },
       path: "dest-object",
       http_method: :put
@@ -170,7 +172,9 @@ defmodule ExAws.S3Test do
                source_encryption: [customer_algorithm: "md5"],
                acl: :public_read,
                destination_encryption: [customer_algorithm: "md5"],
-               meta: [foo: "sqiggles"]
+               meta: [foo: "sqiggles"],
+               tagging: "foo=foo&bar=bar",
+               tagging_directive: :REPLACE
              )
   end
 


### PR DESCRIPTION
Adds support for the `x-amz-tagging-directive` header which is required for the `CopyObject` action when supplying the `x-amz-tagging` header (which is currently supported).

From the [CopyObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html) documentation:
```
x-amz-tagging
The tag-set for the object destination object this value must be used in conjunction with the TaggingDirective.
```

Example usage:

```elixir
ExAws.S3.put_object_copy(
  dest_bucket,
  dest_key,
  src_bucket,
  src_key,
  tagging: "tag1=foo&tag2=bar",
  tagging_directive: :REPLACE
)

# => 

%ExAws.Operation.S3{
  #...
  headers: %{
    "x-amz-copy-source" => "bucket/key",
    "x-amz-tagging" => "tag1=foo&tag2=bar",
    "x-amz-tagging-directive" => :REPLACE
  },
  #...
}
```