### PR TITLE
Adding `bucket_as_host` flag to generate signed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ paths
 |> Stream.run
 ```
 
+### Bucket as host functionality
+#### Examples
+```
+opts = [virtual_host: true, bucket_as_host: true]
+
+ExAws.Config.new(:s3)
+|> S3.presigned_url(:get, "bucket.custom-domain.com", "foo.txt", opts)
+
+{:ok, "https://bucket.custom-domain.com/foo.txt"}
+```
+
 ### Configuration
 
 The `scheme`, `host`, and `port` can be configured to hit alternate endpoints.

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1225,7 +1225,7 @@ defmodule ExAws.S3 do
   When option param `:bucket_as_host` is `true`, the bucket name will be used as the full hostname. 
   In this case, bucket must be set to a full hostname, for example `mybucket.example.com`.
   The `bucket_as_host` must be passed along with `virtual_host=true`
-  
+
   Additional (signed) query parameters can be added to the url by setting option param
   `:query_params` to a list of `{"key", "value"}` pairs. Useful if you are uploading parts of
   a multipart upload directly from the browser.

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1222,10 +1222,10 @@ defmodule ExAws.S3 do
   When option param `:s3_accelerate` is `true`, the bucket name will be used as
   the hostname, along with the `s3-accelerate.amazonaws.com` host.
 
-  When option param `:bucket_as_host` is `true`, the bucket name will be used as
-  the hostname, which will look like `<bucket>.<domain>.com` host.
+  When option param `:bucket_as_host` is `true`, the bucket name will be used as the full hostname. 
+  In this case, bucket must be set to a full hostname, for example `mybucket.example.com`.
   The `bucket_as_host` must be passed along with `virtual_host=true`
-
+  
   Additional (signed) query parameters can be added to the url by setting option param
   `:query_params` to a list of `{"key", "value"}` pairs. Useful if you are uploading parts of
   a multipart upload directly from the browser.

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1344,7 +1344,9 @@ defmodule ExAws.S3 do
           true -> "#{config[:scheme]}#{bucket}#{port}#{object}"
           false -> "#{config[:scheme]}#{bucket}.#{config[:host]}#{port}#{object}"
         end
-      false -> "#{config[:scheme]}#{config[:host]}#{port}/#{bucket}#{object}"
+
+      false ->
+        "#{config[:scheme]}#{config[:host]}#{port}/#{bucket}#{object}"
     end
   end
 

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -395,6 +395,20 @@ defmodule ExAws.S3Test do
     assert_pre_signed_url(url, "https://bucket.s3.amazonaws.com/foo.txt", "3600")
   end
 
+  test "#presigned_url passing both virtual_host and bucket_as_host options" do
+    opts = [virtual_host: false, bucket_as_host: true]
+    {:ok, url} = S3.presigned_url(config(), :get, "bucket", "foo.txt", opts)
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "3600")
+
+    opts = [virtual_host: true, bucket_as_host: false]
+    {:ok, url} = S3.presigned_url(config(), :get, "bucket", "foo.txt", opts)
+    assert_pre_signed_url(url, "https://bucket.s3.amazonaws.com/foo.txt", "3600")
+
+    opts = [virtual_host: true, bucket_as_host: true]
+    {:ok, url} = S3.presigned_url(config(), :get, "bucket.custom-domain.com", "foo.txt", opts)
+    assert_pre_signed_url(url, "https://bucket.custom-domain.com/foo.txt", "3600")
+  end
+
   test "#presigned_url passing query_params option" do
     query_params = [
       key_one: "value_one",


### PR DESCRIPTION
The following PR will allow us to create signed url in the following nomenclature: `https://custom.domain.com/image.jpg?` which wasn't feasible before with this library. This allow us to be independent of amazon host. As in real time scenario when generating signed url for clients side application the IP whitelisting is a well known problem. Certainly this resolve the prior issue as one get better control over custom domain IPs. 
Further benefits with been custom domain as host - provision us to configure authentication layer on access of `presigned` url too.


Inspired from the following issues:
- https://github.com/aws/aws-sdk-js/issues/891
- https://github.com/ex-aws/ex_aws_s3/issues/154

