### PR TITLE
Support updating lifecycles for non-versioned buckets

### DIFF
--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -177,9 +177,15 @@ defmodule ExAws.S3.Utils do
       },
       expiration: %{
         tag: "Expiration",
-        action_tags: fn %{expired_object_delete_marker: marker} ->
-          marker = if marker, do: "true", else: "false"
-          [["<ExpiredObjectDeleteMarker>", marker, "</ExpiredObjectDeleteMarker>"]]
+        action_tags: fn params ->
+          case params do
+            %{expired_object_delete_marker: marker} ->
+              marker = if marker, do: "true", else: "false"
+              [["<ExpiredObjectDeleteMarker>", marker, "</ExpiredObjectDeleteMarker>"]]
+
+            _ ->
+              []
+          end
         end
       },
       noncurrent_version_transition: %{

--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -177,15 +177,13 @@ defmodule ExAws.S3.Utils do
       },
       expiration: %{
         tag: "Expiration",
-        action_tags: fn params ->
-          case params do
-            %{expired_object_delete_marker: marker} ->
-              marker = if marker, do: "true", else: "false"
-              [["<ExpiredObjectDeleteMarker>", marker, "</ExpiredObjectDeleteMarker>"]]
+        action_tags: fn
+          %{expired_object_delete_marker: marker} ->
+            marker = if marker, do: "true", else: "false"
+            [["<ExpiredObjectDeleteMarker>", marker, "</ExpiredObjectDeleteMarker>"]]
 
-            _ ->
-              []
-          end
+          _ ->
+            []
         end
       },
       noncurrent_version_transition: %{

--- a/test/lib/s3/utils_test.exs
+++ b/test/lib/s3/utils_test.exs
@@ -37,37 +37,65 @@ defmodule ExAws.S3.ImplTest do
              }
   end
 
-  test "build_lifecycle_rule" do
-    rule = %{
-      id: "123",
-      enabled: true,
-      filter: %{
-        prefix: "prefix/",
-        tags: %{}
-      },
-      actions: %{
-        transition: %{
-          trigger: {:days, 2},
-          storage: ""
+  describe "build_lifecycle_rule" do
+    test "applying rule to unversioned buckets" do
+      rule = %{
+        id: "123",
+        enabled: true,
+        filter: %{
+          prefix: "prefix/",
+          tags: %{}
         },
-        expiration: %{
-          trigger: {:days, 2},
-          expired_object_delete_marker: true
-        },
-        noncurrent_version_transition: %{
-          trigger: {:days, 2},
-          storage: ""
-        },
-        noncurrent_version_expiration: %{
-          trigger: {:days, 2}
-        },
-        abort_incomplete_multipart_upload: %{
-          trigger: {:days, 2}
+        actions: %{
+          transition: %{
+            trigger: {:days, 2},
+            storage: ""
+          },
+          expiration: %{
+            trigger: {:days, 2}
+          },
+          abort_incomplete_multipart_upload: %{
+            trigger: {:days, 2}
+          }
         }
       }
-    }
 
-    assert rule |> Utils.build_lifecycle_rule() ==
-             "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><NoncurrentVersionExpiration><NoncurrentDays>2</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>2</NoncurrentDays><StorageClass></StorageClass></NoncurrentVersionTransition><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+      assert rule |> Utils.build_lifecycle_rule() ==
+               "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><Expiration><Days>2</Days></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+    end
+
+    test "applying rule to versioned buckets" do
+      rule = %{
+        id: "123",
+        enabled: true,
+        filter: %{
+          prefix: "prefix/",
+          tags: %{}
+        },
+        actions: %{
+          transition: %{
+            trigger: {:days, 2},
+            storage: ""
+          },
+          expiration: %{
+            trigger: {:days, 2},
+            expired_object_delete_marker: true
+          },
+          noncurrent_version_transition: %{
+            trigger: {:days, 2},
+            storage: ""
+          },
+          noncurrent_version_expiration: %{
+            trigger: {:days, 2}
+          },
+          abort_incomplete_multipart_upload: %{
+            trigger: {:days, 2}
+          }
+        }
+      }
+
+      assert rule |> Utils.build_lifecycle_rule() ==
+               "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><NoncurrentVersionExpiration><NoncurrentDays>2</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>2</NoncurrentDays><StorageClass></StorageClass></NoncurrentVersionTransition><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+    end
   end
 end


### PR DESCRIPTION
The S3 docs mention the format for unversioned buckets [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex5).
Notably when the Expiration rule doesn't have a ExpiredObjectDeleteMarker tag which is how it is in our code. This fixed it. Please let me know if there's anything else it needs.

