### PR TITLE
list_objects_v2 to use dedicated streaming function

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -194,7 +194,7 @@ defmodule ExAws.S3 do
       |> Map.put("list-type", 2)
 
     request(:get, bucket, "/", [params: params, headers: opts[:headers]],
-      stream_builder: &ExAws.S3.Lazy.stream_objects!(bucket, opts, &1),
+      stream_builder: &ExAws.S3.Lazy.stream_objects_v2!(bucket, opts, &1),
       parser: &ExAws.S3.Parsers.parse_list_objects/1
     )
   end

--- a/lib/ex_aws/s3/lazy.ex
+++ b/lib/ex_aws/s3/lazy.ex
@@ -27,6 +27,33 @@ defmodule ExAws.S3.Lazy do
     )
   end
 
+  def stream_objects_v2!(bucket, opts, config) do
+    request_fun = fn fun_opts ->
+      ExAws.S3.list_objects_v2(bucket, Keyword.merge(opts, fun_opts))
+      |> ExAws.request!(config)
+      |> Map.get(:body)
+    end
+
+    Stream.resource(
+      fn -> {request_fun, []} end,
+      fn
+        :quit ->
+          {:halt, nil}
+
+        {fun, args} ->
+          case fun.(args) do
+            results = %{is_truncated: "true"} ->
+              {add_results(results, opts),
+               {fun, [continuation_token: results[:next_continuation_token]]}}
+
+            results ->
+              {add_results(results, opts), :quit}
+          end
+      end,
+      & &1
+    )
+  end
+
   def add_results(results, opts) do
     case Keyword.get(opts, :stream_prefixes, nil) do
       nil -> results.contents


### PR DESCRIPTION
There is a bug when you stream `list_objects_v2` that it falls back to use v1 request. As a result some of v2 parameters are not properly recognised. 

This fix creates a new streaming function for v2 and utilises `continuation_token` to fetch the next batch.