### PR TITLE
Use percent encoding instead of www form for header

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1046,7 +1046,7 @@ defmodule ExAws.S3 do
       src_object
       |> String.split("/")
       |> Enum.reject(&(&1 == ""))
-      |> Enum.map(&URI.encode_www_form(&1))
+      |> Enum.map(fn str -> URI.encode(str, &URI.char_unreserved?/1) end)
       |> Enum.join("/")
 
     headers =
@@ -1054,7 +1054,10 @@ defmodule ExAws.S3 do
       |> Map.merge(amz_headers)
       |> Map.merge(source_encryption)
       |> Map.merge(destination_encryption)
-      |> Map.put("x-amz-copy-source", "/#{URI.encode_www_form(src_bucket)}/#{encoded_src_object}")
+      |> Map.put(
+        "x-amz-copy-source",
+        "/#{URI.encode(src_bucket, &URI.char_unreserved?/1)}/#{encoded_src_object}"
+      )
 
     request(:put, dest_bucket, dest_object, headers: headers)
   end

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -219,6 +219,23 @@ defmodule ExAws.S3Test do
              )
   end
 
+  test "#put_object_copy percent encodes spaces" do
+    expected = %Operation.S3{
+      bucket: "dest-bucket",
+      headers: %{"x-amz-copy-source" => "/src-bucket/foo/hello%20friend.txt"},
+      path: "dest-object",
+      http_method: :put
+    }
+
+    assert expected ==
+             S3.put_object_copy(
+               "dest-bucket",
+               "dest-object",
+               "src-bucket",
+               "/foo/hello friend.txt"
+             )
+  end
+
   test "#complete_multipart_upload" do
     expected = %Operation.S3{
       body:


### PR DESCRIPTION
www form is not supported by minio. The AWS docs mention 

> …need to be URL encoded or referenced as HEX.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html

So `%20` should work for spaces.