### PR TITLE
spec: add `bucket_as_host` to `presigned_url_opts`

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -44,6 +44,7 @@ defmodule ExAws.S3 do
           | {:s3_accelerate, boolean}
           | {:query_params, [{binary, binary}]}
           | {:headers, [{binary, binary}]}
+          | {:bucket_as_host, boolean}
         ]
 
   @type presigned_post_opts :: [


### PR DESCRIPTION
From [lib/ex_aws/s3.ex](https://github.com/ex-aws/ex_aws_s3/blob/9856bf268b9b5918c75bb656cee08d486aceb0f1/lib/ex_aws/s3.ex#L1263):

```elixir
  @doc """
  ..(snip)..
  When option param `:bucket_as_host` is `true`, the bucket name will be used as the full hostname.
  In this case, bucket must be set to a full hostname, for example `mybucket.example.com`.
  The `bucket_as_host` must be passed along with `virtual_host=true`
  ..(snip)..
  """
  @spec presigned_url(
          # ..(snip)..
          opts :: presigned_url_opts
        ) :: {:ok, binary} | {:error, binary}
  @one_week 60 * 60 * 24 * 7
  def presigned_url(config, http_method, bucket, object, opts \\ []) do
    # ..(snip)..
    bucket_as_host = Keyword.get(opts, :bucket_as_host, false)
```