### PR TITLE
Swap arg order for copy operations

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -997,16 +997,16 @@ defmodule ExAws.S3 do
 
   @doc "Copy an object"
   @spec put_object_copy(
-          dest_bucket :: binary,
-          dest_object :: binary,
-          src_bucket :: binary,
-          src_object :: binary
-        ) :: ExAws.Operation.S3.t()
-  @spec put_object_copy(
-          dest_bucket :: binary,
-          dest_object :: binary,
           src_bucket :: binary,
           src_object :: binary,
+          dest_bucket :: binary,
+          dest_object :: binary
+        ) :: ExAws.Operation.S3.t()
+  @spec put_object_copy(
+          src_bucket :: binary,
+          src_object :: binary,
+          dest_bucket :: binary,
+          dest_object :: binary,
           opts :: put_object_copy_opts
         ) :: ExAws.Operation.S3.t()
   @amz_headers ~w(
@@ -1017,7 +1017,7 @@ defmodule ExAws.S3 do
     copy_source_if_none_match
     storage_class
     website_redirect_location)a
-  def put_object_copy(dest_bucket, dest_object, src_bucket, src_object, opts \\ []) do
+  def put_object_copy(src_bucket, src_object, dest_bucket, dest_object, opts \\ []) do
     opts = opts |> Map.new()
 
     amz_headers =

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1121,16 +1121,16 @@ defmodule ExAws.S3 do
 
   @doc "Upload a part for a multipart copy"
   @spec upload_part_copy(
-          dest_bucket :: binary,
-          dest_object :: binary,
-          src_bucket :: binary,
-          src_object :: binary
-        ) :: ExAws.Operation.S3.t()
-  @spec upload_part_copy(
-          dest_bucket :: binary,
-          dest_object :: binary,
           src_bucket :: binary,
           src_object :: binary,
+          dest_bucket :: binary,
+          dest_object :: binary
+        ) :: ExAws.Operation.S3.t()
+  @spec upload_part_copy(
+          src_bucket :: binary,
+          src_object :: binary,
+          dest_bucket :: binary,
+          dest_object :: binary,
           opts :: upload_part_copy_opts
         ) :: ExAws.Operation.S3.t()
   @amz_headers ~w(
@@ -1138,7 +1138,7 @@ defmodule ExAws.S3 do
     copy_source_if_unmodified_since
     copy_source_if_match
     copy_source_if_none_match)a
-  def upload_part_copy(dest_bucket, dest_object, src_bucket, src_object, opts \\ []) do
+  def upload_part_copy(src_bucket, src_object, dest_bucket, dest_object, opts \\ []) do
     opts = opts |> Map.new()
 
     source_encryption =

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -165,10 +165,10 @@ defmodule ExAws.S3Test do
 
     assert expected ==
              S3.put_object_copy(
-               "dest-bucket",
-               "dest-object",
                "src-bucket",
                "src-object",
+               "dest-bucket",
+               "dest-object",
                source_encryption: [customer_algorithm: "md5"],
                acl: :public_read,
                destination_encryption: [customer_algorithm: "md5"],
@@ -187,7 +187,7 @@ defmodule ExAws.S3Test do
     }
 
     assert expected ==
-             S3.put_object_copy("dest-bucket", "dest-object", "src-bucket", "src-object")
+             S3.put_object_copy("src-bucket", "src-object", "dest-bucket", "dest-object")
   end
 
   test "#put_object_copy utf8" do
@@ -199,7 +199,7 @@ defmodule ExAws.S3Test do
     }
 
     assert expected ==
-             S3.put_object_copy("dest-bucket", "dest-object", "src-bucket", "/foo/ü.txt")
+             S3.put_object_copy("src-bucket", "/foo/ü.txt", "dest-bucket", "dest-object")
   end
 
   test "#put_object_copy encoding" do
@@ -212,10 +212,10 @@ defmodule ExAws.S3Test do
 
     assert expected ==
              S3.put_object_copy(
-               "dest-bucket",
-               "dest-object",
                "src-bucket",
-               "/foo/hello+friend.txt"
+               "/foo/hello+friend.txt",
+               "dest-bucket",
+               "dest-object"
              )
   end
 
@@ -229,10 +229,10 @@ defmodule ExAws.S3Test do
 
     assert expected ==
              S3.put_object_copy(
-               "dest-bucket",
-               "dest-object",
                "src-bucket",
-               "/foo/hello friend.txt"
+               "/foo/hello friend.txt",
+               "dest-bucket",
+               "dest-object"
              )
   end
 

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -269,10 +269,10 @@ defmodule ExAws.S3Test do
 
     assert expected ==
              S3.upload_part_copy(
-               "dest-bucket",
-               "dest-object",
                "src-bucket",
                "src-object",
+               "dest-bucket",
+               "dest-object",
                source_encryption: [customer_algorithm: "md5"],
                copy_source_range: 1..9
              )


### PR DESCRIPTION
This PR is intended to address issue #191 

It swaps the argument order of `put_object_copy/5` and `upload_part_copy/5` so that the source comes _before_ the destination.  This is done to reduce confusion by following the convention used by Bash's `cp` command, the `awscli s3 cp` command, and others.

```
def put_object_copy(dest_bucket, dest_object, src_bucket, src_object, opts \\ []) do
```
becomes
```
def put_object_copy(src_bucket, src_object, dest_bucket, dest_object, opts \\ []) do
```
and
```
def upload_part_copy(dest_bucket, dest_object, src_bucket, src_object, opts \\ []) do
```
becomes
```
def upload_part_copy(src_bucket, src_object, dest_bucket, dest_object, opts \\ []) do
```

Tests have been updated.
