### PR TITLE
Feat: Capture the actual error message for downloading

### DIFF
--- a/lib/ex_aws/s3/download.ex
+++ b/lib/ex_aws/s3/download.ex
@@ -89,7 +89,7 @@ defimpl ExAws.Operation, for: ExAws.S3.Download do
       e ->
         File.close(file)
         File.rm(op.dest)
-        {:error, "error downloading file", e}
+        {:error, e}
     end
   end
 

--- a/lib/ex_aws/s3/download.ex
+++ b/lib/ex_aws/s3/download.ex
@@ -86,10 +86,10 @@ defimpl ExAws.Operation, for: ExAws.S3.Download do
 
       {:ok, :done}
     rescue
-      _ ->
+      e ->
         File.close(file)
         File.rm(op.dest)
-        {:error, "error downloading file"}
+        {:error, "error downloading file", e}
     end
   end
 


### PR DESCRIPTION
Problem: 
- currently it is hard to understand, what actually went wrong during a failed download

Solution: 
- return also the captured error in the rescue clause of try … rescue statement