### PR TITLE
Update storage class types

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -28,6 +28,19 @@ defmodule ExAws.S3 do
           | {:uri, binary}
         ]
 
+  @type storage_class_opt :: {:storage_class, storage_class}
+  @type storage_class ::
+          :standard
+          | :reduced_redundancy
+          | :standard_ia
+          | :onezone_ia
+          | :intelligent_tiering
+          | :glacier
+          | :deep_archive
+          | :outposts
+          | :glacier_ir
+          | :snow
+
   @type customer_encryption_opts :: [
           customer_algorithm: binary,
           customer_key: binary,
@@ -898,11 +911,11 @@ defmodule ExAws.S3 do
           | {:content_type, binary}
           | {:expect, binary}
           | {:expires, binary}
-          | {:storage_class, :standard | :reduced_redundancy}
           | {:website_redirect_location, binary}
           | {:encryption, encryption_opts}
           | {:meta, amz_meta_opts}
           | acl_opt
+          | storage_class_opt
         ]
   @doc "Create an object within a bucket"
   @spec put_object(bucket :: binary, object :: binary, body :: binary) :: ExAws.Operation.S3.t()
@@ -992,10 +1005,10 @@ defmodule ExAws.S3 do
           | {:content_type, binary}
           | {:expect, binary}
           | {:expires, binary}
-          | {:storage_class, :standard | :reduced_redundancy}
           | {:website_redirect_location, binary}
           | {:meta, amz_meta_opts}
           | acl_opt
+          | storage_class_opt
         ]
 
   @doc "Copy an object"
@@ -1072,10 +1085,10 @@ defmodule ExAws.S3 do
           | {:content_encoding, binary}
           | {:content_type, binary}
           | {:expires, binary}
-          | {:storage_class, :standard | :reduced_redundancy}
           | {:website_redirect_location, binary}
           | {:encryption, encryption_opts}
           | acl_opt
+          | storage_class_opt
   @type initiate_multipart_upload_opts :: [initiate_multipart_upload_opt]
 
   @doc "Initiate a multipart upload"

--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -15,7 +15,9 @@ defmodule ExAws.S3.Utils do
     :expires,
     :content_md5
   ]
-  @amz_headers [:storage_class, :website_redirect_location, :tagging, :tagging_directive]
+
+  @amz_headers [:website_redirect_location, :tagging, :tagging_directive]
+
   def put_object_headers(opts) do
     opts = opts |> Map.new()
 
@@ -27,6 +29,8 @@ defmodule ExAws.S3.Utils do
       opts
       |> format_and_take(@amz_headers)
       |> namespace("x-amz")
+
+    storage_class_headers = format_storage_class_headers(opts)
 
     acl_headers = format_acl_headers(opts)
 
@@ -42,6 +46,7 @@ defmodule ExAws.S3.Utils do
 
     regular_headers
     |> Map.merge(amz_headers)
+    |> Map.merge(storage_class_headers)
     |> Map.merge(acl_headers)
     |> Map.merge(encryption_headers)
     |> Map.merge(meta)
@@ -74,6 +79,17 @@ defmodule ExAws.S3.Utils do
     |> Map.new()
     |> format_and_take(param_list)
   end
+
+  def format_storage_class_headers(%{storage_class: storage_class}) do
+    formatted_storage_class =
+      storage_class
+      |> to_string()
+      |> String.upcase()
+
+    %{"x-amz-storage-class" => formatted_storage_class}
+  end
+
+  def format_storage_class_headers(_), do: %{}
 
   @acl_headers [
     :acl,

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -81,7 +81,7 @@ defmodule ExAws.S3Test do
         "content-encoding" => "application/json",
         "x-amz-acl" => "public-read",
         "x-amz-server-side-encryption" => "AES256",
-        "x-amz-storage-class" => "spicy",
+        "x-amz-storage-class" => "GLACIER_IR",
         "content-md5" => "asdf",
         "x-amz-meta-foo" => "sqiggles"
       },
@@ -95,7 +95,7 @@ defmodule ExAws.S3Test do
                "object.json",
                "data",
                content_encoding: "application/json",
-               storage_class: "spicy",
+               storage_class: :glacier_ir,
                content_md5: "asdf",
                acl: :public_read,
                encryption: "AES256",


### PR DESCRIPTION
I updated the `x-amz-storage-class` header to more-formally support the storage classes Amazon has listed [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html).

The following screenshot is taken from Amazon's [PutObject documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html).
<img width="495" alt="image" src="https://github.com/ex-aws/ex_aws_s3/assets/8103973/c836a4e6-fe67-4aa6-a873-54e520833ddf">

To do this I needed to slightly alter some default behavior. The typespecs for storage class originally showed acceptable values of `:standard` and `:reduced_redundancy`. I expanded those to include lowercase, atomized versions of the storage classes listed above. The test for storage class showed that a string was acceptable as well. Strings are still acceptable but now they will be upcased. Atoms will be stringified and upcased.