### PR TITLE
Multipart copy requires upload id, part number, and source range

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -2,19 +2,6 @@ if Code.ensure_loaded?(SweetXml) do
   defmodule ExAws.S3.Parsers do
     import SweetXml, only: [sigil_x: 2]
 
-    def parse_upload({:ok, resp = %{body: xml}}) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//CompleteMultipartUploadResult",
-          location: ~x"./Location/text()"s,
-          bucket: ~x"./Bucket/text()"s,
-          key: ~x"./Key/text()"s,
-          eTag: ~x"./ETag/text()"s
-        )
-
-      {:ok, %{resp | body: parsed_body}}
-    end
-
     def parse_list_objects({:ok, resp = %{body: xml}}) do
       parsed_body =
         xml
@@ -86,8 +73,28 @@ if Code.ensure_loaded?(SweetXml) do
 
     def parse_initiate_multipart_upload(val), do: val
 
-    def parse_upload_part_copy(val), do: val
-    def parse_complete_multipart_upload(val), do: val
+    def parse_upload_part_copy({:ok, resp = %{body: xml}}) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//CopyPartResult",
+         last_modified: ~x"./LastModified/text()"s,
+         etag: ~x"./ETag/text()"s
+      )
+
+      {:ok, %{resp | body: parsed_body}}
+    end
+
+    def parse_complete_multipart_upload({:ok, resp = %{body: xml}}) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//CompleteMultipartUploadResult",
+         location: ~x"./Location/text()"s,
+         bucket: ~x"./Bucket/text()"s,
+         key: ~x"./Key/text()"s,
+         etag: ~x"./ETag/text()"s
+      )
+
+      {:ok, %{resp | body: parsed_body}}
+    end
+
 
     def parse_list_multipart_uploads({:ok, %{body: xml} = resp}) do
       parsed_body =

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -1,27 +1,6 @@
 defmodule ExAws.S3.ParserTest do
   use ExUnit.Case, async: true
 
-  test "#parse_upload parses CompleteMultipartUploadResult" do
-    upload_response = """
-    <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/\">
-      <Location>https://google.com</Location>
-      <Bucket>name_of_my_bucket</Bucket>
-      <Key>name_of_my_key.ext</Key>
-      <ETag>&quot;89asdfasdf0asdfasdfasd&quot;</ETag>
-    </CompleteMultipartUploadResult>
-    """
-
-    result = ExAws.S3.Parsers.parse_upload({:ok, %{body: upload_response}})
-    {:ok, %{body: parsed_body}} = result
-
-    assert parsed_body == %{
-             location: "https://google.com",
-             bucket: "name_of_my_bucket",
-             key: "name_of_my_key.ext",
-             eTag: "\"89asdfasdf0asdfasdfasd\""
-           }
-  end
-
   test "#parse_list_objects parses CommonPrefixes" do
     list_objects_response = """
     <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -324,5 +303,41 @@ defmodule ExAws.S3.ParserTest do
     assert delete_marker1[:last_modified] == "2009-11-12T17:50:30.000Z"
     assert is_map(delete_marker1[:owner])
     assert delete_marker1[:owner][:display_name] == "noone@example.com"
+  end
+
+  test "#parse_upload_part_copy parses response" do
+    parse_upload_part_copy_response = """
+    <CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <LastModified>2019-02-09T06:27:26.000Z</LastModified>
+      <ETag>&quot;7cbef1ad67ecd0d9ba35af98d3de5a94&quot;</ETag>
+    </CopyPartResult>
+    """
+
+    result = ExAws.S3.Parsers.parse_upload_part_copy({:ok, %{body: parse_upload_part_copy_response}})
+    {:ok, %{body: %{last_modified: last_modified, etag: etag}}} = result
+
+    assert "2019-02-09T06:27:26.000Z" == last_modified
+    assert "\"7cbef1ad67ecd0d9ba35af98d3de5a94\"" == etag
+  end
+
+  test "#parse_complete_multipart_upload parses CompleteMultipartUploadResult" do
+    complete_multipart_upload_response = """
+    <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <Location>https://s3-eu-west-1.amazonaws.com/my-bucket/tmp-copy3.mp4</Location>
+      <Bucket>my-bucket</Bucket>
+      <Key>tmp-copy3.mp4</Key>
+      <ETag>&quot;17fbc0a106abbb6f381aac6e331f2a19-1&quot;</ETag>
+    </CompleteMultipartUploadResult>
+    """
+
+    result = ExAws.S3.Parsers.parse_complete_multipart_upload({:ok, %{body: complete_multipart_upload_response}})
+    {:ok, %{body: body}} = result
+
+    assert body == %{
+      location: "https://s3-eu-west-1.amazonaws.com/my-bucket/tmp-copy3.mp4",
+      bucket: "my-bucket",
+      key: "tmp-copy3.mp4",
+      etag: "\"17fbc0a106abbb6f381aac6e331f2a19-1\""
+    }
   end
 end

--- a/test/lib/s3/upload_test.exs
+++ b/test/lib/s3/upload_test.exs
@@ -33,10 +33,18 @@ defmodule ExAws.S3.UploadTest do
 
       case conn do
         %{method: "POST", request_path: ^request_path, query_params: %{"uploadId" => ^upload_id}} ->
+          body = """
+          <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Location>https://s3-eu-west-1.amazonaws.com/my-bucket/#{path}</Location>
+            <Bucket>#{bucket_name}</Bucket>
+            <Key>#{path}</Key>
+            <ETag>&quot;17fbc0a106abbb6f381aac6e331f2a19-1&quot;</ETag>
+          </CompleteMultipartUploadResult>
+          """
           send(test_pid, :completed_upload)
 
           conn
-          |> Plug.Conn.send_resp(200, "")
+          |> Plug.Conn.send_resp(200, body)
 
         %{method: "POST", request_path: ^request_path} ->
           body = """

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -262,6 +262,7 @@ defmodule ExAws.S3Test do
         "x-amz-copy-source-range" => "bytes=1-9",
         "x-amz-copy-source-server-side-encryption-customer-algorithm" => "md5"
       },
+      params: %{"uploadId" => "upload-id", "partNumber" => 1},
       path: "dest-object",
       http_method: :put,
       parser: &ExAws.S3.Parsers.parse_upload_part_copy/1
@@ -273,8 +274,10 @@ defmodule ExAws.S3Test do
                "dest-object",
                "src-bucket",
                "src-object",
-               source_encryption: [customer_algorithm: "md5"],
-               copy_source_range: 1..9
+               "upload-id",
+               1,
+               1..9,
+               source_encryption: [customer_algorithm: "md5"]
              )
   end
 


### PR DESCRIPTION
Trying to revive #106, which seemed to have gone dormant. The current implementation of `upload_part_copy` does not seem to work at all, and this fixes it.

This is a slightly different take. Like `S3.upload_part`, the upload_id, the part number, and the range are required attributes and shouldn't be put into opts, but part of the explicit API. Other than that, I copied the code mostly verbatim from #106 and just ensured it merged cleanly.