### PR TITLE
Need to handle error cases for parse_upload_part_copy

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -84,6 +84,8 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, %{resp | body: parsed_body}}
     end
 
+    def parse_upload_part_copy(val), do: val
+
     def parse_complete_multipart_upload({:ok, resp = %{body: xml}}) do
       parsed_body =
         xml

--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -73,7 +73,7 @@ if Code.ensure_loaded?(SweetXml) do
 
     def parse_initiate_multipart_upload(val), do: val
 
-    def parse_upload_part_copy({:ok, resp = %{body: xml}}) do
+    def parse_upload_part_copy({:ok, resp = %{body: xml}}) when is_binary(xml) do
       parsed_body =
         xml
         |> SweetXml.xpath(~x"//CopyPartResult",
@@ -82,6 +82,12 @@ if Code.ensure_loaded?(SweetXml) do
         )
 
       {:ok, %{resp | body: parsed_body}}
+    end
+
+    # In actual usage we've seen an error from a nil body being passed to
+    # SweetXml, so we don't want to do that
+    def parse_upload_part_copy({:ok, resp})  do
+      {:error, resp}
     end
 
     def parse_upload_part_copy(val), do: val

--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -86,7 +86,7 @@ if Code.ensure_loaded?(SweetXml) do
 
     # In actual usage we've seen an error from a nil body being passed to
     # SweetXml, so we don't want to do that
-    def parse_upload_part_copy({:ok, resp})  do
+    def parse_upload_part_copy({:ok, resp}) do
       {:error, resp}
     end
 

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -308,11 +308,11 @@ defmodule ExAws.S3.ParserTest do
   describe "#parse_upload_part_copy" do
     test "parses a good response" do
       parse_upload_part_copy_response = """
-        <CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-        <LastModified>2019-02-09T06:27:26.000Z</LastModified>
-        <ETag>&quot;7cbef1ad67ecd0d9ba35af98d3de5a94&quot;</ETag>
-        </CopyPartResult>
-        """
+      <CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <LastModified>2019-02-09T06:27:26.000Z</LastModified>
+      <ETag>&quot;7cbef1ad67ecd0d9ba35af98d3de5a94&quot;</ETag>
+      </CopyPartResult>
+      """
 
       result =
         ExAws.S3.Parsers.parse_upload_part_copy({:ok, %{body: parse_upload_part_copy_response}})

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -305,21 +305,33 @@ defmodule ExAws.S3.ParserTest do
     assert delete_marker1[:owner][:display_name] == "noone@example.com"
   end
 
-  test "#parse_upload_part_copy parses response" do
-    parse_upload_part_copy_response = """
-    <CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-      <LastModified>2019-02-09T06:27:26.000Z</LastModified>
-      <ETag>&quot;7cbef1ad67ecd0d9ba35af98d3de5a94&quot;</ETag>
-    </CopyPartResult>
-    """
+  describe "#parse_upload_part_copy" do
+    test "parses a good response" do
+      parse_upload_part_copy_response = """
+        <CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <LastModified>2019-02-09T06:27:26.000Z</LastModified>
+        <ETag>&quot;7cbef1ad67ecd0d9ba35af98d3de5a94&quot;</ETag>
+        </CopyPartResult>
+        """
 
-    result =
-      ExAws.S3.Parsers.parse_upload_part_copy({:ok, %{body: parse_upload_part_copy_response}})
+      result =
+        ExAws.S3.Parsers.parse_upload_part_copy({:ok, %{body: parse_upload_part_copy_response}})
 
-    {:ok, %{body: %{last_modified: last_modified, etag: etag}}} = result
+      assert {:ok, %{body: %{last_modified: last_modified, etag: etag}}} = result
+      assert "2019-02-09T06:27:26.000Z" == last_modified
+      assert "\"7cbef1ad67ecd0d9ba35af98d3de5a94\"" == etag
+    end
 
-    assert "2019-02-09T06:27:26.000Z" == last_modified
-    assert "\"7cbef1ad67ecd0d9ba35af98d3de5a94\"" == etag
+    test "handles nil" do
+      result = ExAws.S3.Parsers.parse_upload_part_copy({:ok, %{body: nil}})
+      assert {:error, %{body: nil}} == result
+    end
+
+    test "handles errors by passing them through" do
+      error = {:error, "error"}
+      result = ExAws.S3.Parsers.parse_upload_part_copy(error)
+      assert result == error
+    end
   end
 
   test "#parse_complete_multipart_upload parses CompleteMultipartUploadResult" do


### PR DESCRIPTION
Realized we were missing a fall-through for when pattern matching failed on this parser.