### PR TITLE
Avoid using hardcoded MD5 when calculating hash of content.

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -978,12 +978,12 @@ defmodule ExAws.S3 do
       "</Tagging>"
     ]
 
-    content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
+    # content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
 
     headers =
       opts
       |> Map.new()
-      |> Map.merge(%{"content-md5" => content_md5})
+#      |> Map.merge(%{"content-md5" => content_md5})
 
     body_binary = body |> IO.iodata_to_binary()
 

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -85,9 +85,7 @@ defmodule ExAws.S3 do
   @spec list_buckets() :: ExAws.Operation.S3.t()
   @spec list_buckets(opts :: Keyword.t()) :: ExAws.Operation.S3.t()
   def list_buckets(opts \\ []) do
-    request(:get, "", "/", [params: opts],
-      parser: &ExAws.S3.Parsers.parse_all_my_buckets_result/1
-    )
+    request(:get, "", "/", [params: opts], parser: &ExAws.S3.Parsers.parse_all_my_buckets_result/1)
   end
 
   @doc "Delete a bucket"
@@ -574,7 +572,7 @@ defmodule ExAws.S3 do
 
     request(:post, bucket, "/?delete",
       body: body_binary,
-      headers: calculate_content_header(body)
+      headers: calculate_content_header(body_binary)
     )
   end
 
@@ -992,17 +990,18 @@ defmodule ExAws.S3 do
     )
   end
 
+  @spec calculate_content_header(iodata()) :: map()
   def calculate_content_header(content),
     do: calculate_content_hash(content) |> pair_tuple_to_map()
 
   @spec calculate_content_hash(iodata()) :: {binary(), binary()}
-  def calculate_content_hash(content) do
+  defp calculate_content_hash(content) do
     alg = get_hash_config()
     {hash_header(alg), :crypto.hash(alg, content) |> Base.encode64()}
   end
 
   @spec get_hash_config() :: :md5
-  def get_hash_config() do
+  defp get_hash_config() do
     Application.get_env(:ex_aws_s3, :content_hash_algorithm) || :md5
   end
 

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1006,18 +1006,10 @@ defmodule ExAws.S3 do
     Application.get_env(:ex_aws_s3, :content_hash_algorithm) || :md5
   end
 
-  # TODO replace atom() with expected values
-
+  # Supported hash algorithms:
+  # https://www.erlang.org/doc/man/crypto.html#type-hash_algorithm
   @spec hash_header(atom()) :: binary()
-  defp hash_header(alg) do
-    case alg do
-      :md5 -> header_val(alg)
-      :sha256 -> header_val(alg)
-    end
-  end
-
-  @spec header_val(atom()) :: binary()
-  defp header_val(alg), do: "content-#{to_string(alg)}"
+  defp hash_header(alg) when is_atom(alg), do: "content-#{to_string(alg)}"
 
   @spec pair_tuple_to_map({term(), term()}) :: map()
   defp pair_tuple_to_map(tuple), do: Map.new([tuple])

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -350,8 +350,8 @@ defmodule ExAws.S3 do
       |> IO.iodata_to_binary()
 
     body = "<CORSConfiguration>#{rules}</CORSConfiguration>"
-    content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
-    headers = %{"content-md5" => content_md5}
+    content_hash = :crypto.hash(:md5, body) |> Base.encode64()
+    headers = %{"content-md5" => content_hash}
 
     request(:put, bucket, "/", resource: "cors", body: body, headers: headers)
   end
@@ -412,8 +412,8 @@ defmodule ExAws.S3 do
 
     body = "<LifecycleConfiguration>#{rules}</LifecycleConfiguration>"
 
-    content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
-    headers = %{"content-md5" => content_md5}
+    content_hash = :crypto.hash(:md5, body) |> Base.encode64()
+    headers = %{"content-md5" => content_hash}
 
     request(:put, bucket, "/", resource: "lifecycle", body: body, headers: headers)
   end
@@ -475,8 +475,8 @@ defmodule ExAws.S3 do
   @spec put_bucket_versioning(bucket :: binary, version_config :: binary) ::
           ExAws.Operation.S3.t()
   def put_bucket_versioning(bucket, version_config) do
-    content_md5 = :crypto.hash(:md5, version_config) |> Base.encode64()
-    headers = %{"content-md5" => content_md5}
+    content_hash = :crypto.hash(:md5, version_config) |> Base.encode64()
+    headers = %{"content-md5" => content_hash}
     request(:put, bucket, "/", resource: "versioning", body: version_config, headers: headers)
   end
 
@@ -572,12 +572,12 @@ defmodule ExAws.S3 do
       "</Delete>"
     ]
 
-    content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
+    content_hash = :crypto.hash(:md5, body) |> Base.encode64()
     body_binary = body |> IO.iodata_to_binary()
 
     request(:post, bucket, "/?delete",
       body: body_binary,
-      headers: %{"content-md5" => content_md5}
+      headers: %{"content-md5" => content_hash}
     )
   end
 
@@ -978,12 +978,12 @@ defmodule ExAws.S3 do
       "</Tagging>"
     ]
 
-    # content_md5 = :crypto.hash(:md5, body) |> Base.encode64()
+    # content_hash = :crypto.hash(:md5, body) |> Base.encode64()
 
     headers =
       opts
       |> Map.new()
-#      |> Map.merge(%{"content-md5" => content_md5})
+#      |> Map.merge(%{"content-md5" => content_hash})
 
     body_binary = body |> IO.iodata_to_binary()
 

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1006,11 +1006,18 @@ defmodule ExAws.S3 do
     Application.get_env(:ex_aws_s3, :content_hash_algorithm) || :md5
   end
 
+  # TODO replace atom() with expected values
+
+  @spec hash_header(atom()) :: binary()
   defp hash_header(alg) do
     case alg do
-      :md5 -> "content-md5"
+      :md5 -> header_val(alg)
+      :sha256 -> header_val(alg)
     end
   end
+
+  @spec header_val(atom()) :: binary()
+  defp header_val(alg), do: "content-#{to_string(alg)}"
 
   @spec pair_tuple_to_map({term(), term()}) :: map()
   defp pair_tuple_to_map(tuple), do: Map.new([tuple])

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -690,6 +690,15 @@ defmodule ExAws.S3Test do
     assert url == "https://bucket.custom-domain.com"
   end
 
+  describe "Content hash header" do
+    test "MD5" do
+      body = "hello world"
+      content_hash = :crypto.hash(:md5, body) |> Base.encode64()
+      expected = %{"content-md5" => content_hash}
+      assert ExAws.S3.calculate_content_header("hello world") === expected
+    end
+  end
+
   @spec assert_pre_signed_url(
           url,
           expected_scheme_host_path,


### PR DESCRIPTION
The PR leaves

- MD5 as default, so existing code and users of this library would not be affected.

Introduces 
- the configuration `content_hash_algorithm` under `ex_aws_s3`.

As a result, the library `ex_aws_s3` could use other encryption algorithms other than MD5 which is not FIPS compliant. So may be necessary for some to be able to set the hashing algorithm used.