### PR TITLE
Add option to get auth from AuthCache on every request when uploading  to S3 in a stream

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -760,6 +760,7 @@ defmodule ExAws.S3 do
   @type upload_opt ::
           {:max_concurrency, pos_integer}
           | {:timeout, pos_integer}
+          | {:refetch_auth_on_request, boolean}
           | initiate_multipart_upload_opt
   @type upload_opts :: [upload_opt]
 
@@ -786,6 +787,9 @@ defmodule ExAws.S3 do
   * See `Task.async_stream/5`'s `:max_concurrency` and `:timeout` options.
     * `:max_concurrency` - only applies when uploading a stream. Sets the maximum number of tasks to run at the same time. Defaults to `4`
     * `:timeout` - the maximum amount of time (in milliseconds) each task is allowed to execute for. Defaults to `30_000`.
+    * `:refetch_auth_on_request` - re-fetch the auth from the library config on each request in the upload process instead of using
+      the initial auth. Fixes an edge case uploading large files when using a strategy from `ex_aws_sts` that provides short lived tokens,
+      where uploads could fail if the token expires before the upload is completed. Defaults to `false`.
 
   All other options (ex. `:content_type`) are passed through to
   `ExAws.S3.initiate_multipart_upload/3`.


### PR DESCRIPTION
Adds the option `:refetch_auth_on_request` to `ExAws.S3.upload/4`. This will re-fetch the auth from the library config on each request in the upload process instead of using the initial auth. 

Fixes an edge case uploading large files when using a strategy from `ex_aws_sts` that provides short lived tokens, where uploads could fail if the token expires before the upload is completed. Defaults to `false`.

## Example

If using [`ex_aws_sts`](https://github.com/ex-aws/ex_aws_sts), short authentication tokens are generated and cached according to the config. However, they are only fetched **once** from the auth cache when this call is made.

```elixir
file
|> ExAws.S3.upload_file()
|> ExAws.S3.upload("bucket_foo", "object_id")
|> ExAws.request()
```

There are three requests that need authentication in `ExAws.S3.Upload.perform/2`, one to start the upload, one to stream the data, and one to complete the upload. If the streaming upload takes longer than the token's expiration time, the call to `ExAws.S3.Upload.complete/2` will fail because the token is expired. Note: the stream does not fail if the token expires. The assumption is that the request is still authenticated because it's all one stream.

