### PR TITLE
Resolve Dialyzer errors on Elixir 1.16

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         otp: [23.x, 24.x, 25.x]
-        elixir: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        elixir: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x]
         exclude:
           - otp: 25.x
             elixir: 1.11.x

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -18,6 +18,8 @@ jobs:
             elixir: 1.12.x
           - otp: 23.x
             elixir: 1.15.x
+          - otp: 23.x
+            elixir: 1.16.x
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/lib/ex_aws/s3/upload.ex
+++ b/lib/ex_aws/s3/upload.ex
@@ -67,8 +67,10 @@ defmodule ExAws.S3.Upload do
   """
   @spec stream_file(path :: binary) :: File.Stream.t()
   @spec stream_file(path :: binary, opts :: [chunk_size: pos_integer]) :: File.Stream.t()
-  def stream_file(path, opts \\ []) do
-    File.stream!(path, [], opts[:chunk_size] || 5 * 1024 * 1024)
+  if Version.compare(System.version(), "1.16.0") in [:gt, :eq] do
+    def stream_file(path, opts \\ []), do: File.stream!(path, opts[:chunk_size] || 5 * 1024 * 1024)
+  else
+    def stream_file(path, opts \\ []), do: File.stream!(path, [], opts[:chunk_size] || 5 * 1024 * 1024)
   end
 
   @doc """


### PR DESCRIPTION
The following Dialyzer errors show up in Elixir 1.16, which then result in “has no local return” Dialyzer errors in clients of this library. This PR resolves them in a backwards compatible way.

```
lib/ex_aws/s3/upload.ex:70: Function stream_file/1 has no local return
lib/ex_aws/s3/upload.ex:70: Function stream_file/2 has no local return
lib/ex_aws/s3/upload.ex:71: The call 'Elixir.File':'stream!'(_path@1::any(),[],any()) breaks the contract ('Elixir.Path':t(),'line' | pos_integer(),[stream_mode()]) -> 'Elixir.File.Stream':t()
```

ref: https://github.com/elixir-lang/elixir/issues/13212