### PR TITLE
Append x-amz-checksum headers when using hashing algorithm other than MD5

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ config :ex_aws, :s3,
   port: 9000
 ```
 
-An alternate `content_hash_algorithm` can be specified as well. The default is `:md5`. It may be necessary to change this when operating in a FIPS-compliant environment where MD5 isn't available, for instance. At this time, only `:sha256` and `:sha` are supported by both Erlang and S3.
+An alternate `content_hash_algorithm` can be specified as well. The default is `:md5`. It may be necessary to change this when operating in a FIPS-compliant environment where MD5 isn't available, for instance. At this time, only `:sha256`, `:sha`, and `:md5` are supported by both Erlang and S3.
 
 ``` elixir
 # config.exs

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ config :ex_aws, :s3,
   port: 9000
 ```
 
+An alternate `content_hash_algorithm` can be specified as well. The default is `:md5`. It may be necessary to change this when operating in a FIPS-compliant environment where MD5 isn't available, for instance. At this time, only `:sha256` and `:sha` are supported by both Erlang and S3.
+
+``` elixir
+# config.exs
+config :ex_aws_s3, :content_hash_algorithm, :sha256
+```
+
 <!-- MDOC !-->
 
 ## License

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1014,7 +1014,8 @@ defmodule ExAws.S3 do
   # Supported hash algorithms:
   # https://www.erlang.org/doc/man/crypto.html#type-hash_algorithm
   @spec hash_header(atom()) :: binary()
-  defp hash_header(alg) when is_atom(alg), do: "content-#{to_string(alg)}"
+  defp hash_header(:md5), do: "content-md5"
+  defp hash_header(alg) when is_atom(alg), do: "x-amz-checksum-#{to_string(alg)}"
 
   @spec pair_tuple_to_map({term(), term()}) :: map()
   defp pair_tuple_to_map(tuple), do: Map.new([tuple])

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1006,7 +1006,7 @@ defmodule ExAws.S3 do
     {hash_header(alg), :crypto.hash(alg, content) |> Base.encode64()}
   end
 
-  @spec get_hash_config() :: :md5
+  @spec get_hash_config() :: atom()
   defp get_hash_config() do
     Application.get_env(:ex_aws_s3, :content_hash_algorithm) || :md5
   end

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -79,6 +79,14 @@ defmodule ExAws.S3 do
 
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]
 
+  @typedoc """
+  The hashing algorithms that S3 supports for content integrity.
+  Erlang only supports sha1 and sha256.
+
+  https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+  """
+  @type hash_algorithm :: :crc32 | :crc32c | :sha1 | :sha256
+
   ## Buckets
   #############
   @doc "List buckets"
@@ -1011,10 +1019,11 @@ defmodule ExAws.S3 do
     Application.get_env(:ex_aws_s3, :content_hash_algorithm) || :md5
   end
 
-  # Supported hash algorithms:
+  # Supported erlang hash algorithms:
   # https://www.erlang.org/doc/man/crypto.html#type-hash_algorithm
-  @spec hash_header(atom()) :: binary()
+  @spec hash_header(hash_algorithm()) :: binary()
   defp hash_header(:md5), do: "content-md5"
+  defp hash_header(:sha), do: "x-amz-checksum-sha1"
   defp hash_header(alg) when is_atom(alg), do: "x-amz-checksum-#{to_string(alg)}"
 
   @spec pair_tuple_to_map({term(), term()}) :: map()

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -80,12 +80,12 @@ defmodule ExAws.S3 do
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]
 
   @typedoc """
-  The hashing algorithms that S3 supports for content integrity.
-  Erlang only supports sha1 and sha256.
+  The hashing algorithms that both S3 and Erlang support.
 
   https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+  https://www.erlang.org/doc/man/crypto.html#type-hash_algorithm
   """
-  @type hash_algorithm :: :crc32 | :crc32c | :sha1 | :sha256
+  @type hash_algorithm :: :sha | :sha256 | :md5
 
   ## Buckets
   #############
@@ -1014,7 +1014,7 @@ defmodule ExAws.S3 do
     {hash_header(alg), :crypto.hash(alg, content) |> Base.encode64()}
   end
 
-  @spec get_hash_config() :: atom()
+  @spec get_hash_config() :: hash_algorithm()
   defp get_hash_config() do
     Application.get_env(:ex_aws_s3, :content_hash_algorithm) || :md5
   end

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -1,5 +1,6 @@
 defmodule ExAws.S3Test do
-  use ExUnit.Case, async: true
+  # Setting async: false since we're modifying Application env
+  use ExUnit.Case, async: false
   alias ExAws.{S3, Operation}
 
   test "#list_objects" do
@@ -335,6 +336,28 @@ defmodule ExAws.S3Test do
                {"bar", "v1"},
                "special characters: '\"&<>\r\n"
              ])
+  end
+
+  test "#delete_multiple_objects sha256" do
+    set_content_hash_algorithm()
+
+    expected = %Operation.S3{
+      body:
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Delete><Object><Key>foo</Key></Object><Object><Key>bar</Key><VersionId>v1</VersionId></Object><Object><Key>special characters: &apos;&quot;&amp;&lt;&gt;&#13;&#10;</Key></Object></Delete>",
+      bucket: "bucket",
+      path: "/?delete",
+      headers: %{"x-amz-checksum-sha256" => "Hsce+MZp64Uy8CwyResJ3y13YGw6jDAAdVGFmFPKPSs="},
+      http_method: :post
+    }
+
+    assert expected ==
+             S3.delete_multiple_objects("bucket", [
+               "foo",
+               {"bar", "v1"},
+               "special characters: '\"&<>\r\n"
+             ])
+
+    unset_content_hash_algorithm()
   end
 
   test "#post_object_restore" do
@@ -697,6 +720,25 @@ defmodule ExAws.S3Test do
       expected = %{"content-md5" => content_hash}
       assert ExAws.S3.calculate_content_header("hello world") === expected
     end
+
+    test "SHA256" do
+      set_content_hash_algorithm()
+
+      body = "hello world"
+      content_hash = :crypto.hash(:sha256, body) |> Base.encode64()
+      expected = %{"x-amz-checksum-sha256" => content_hash}
+      assert ExAws.S3.calculate_content_header("hello world") === expected
+
+      unset_content_hash_algorithm()
+    end
+  end
+
+  defp set_content_hash_algorithm() do
+    Application.put_env(:ex_aws_s3, :content_hash_algorithm, :sha256)
+  end
+
+  defp unset_content_hash_algorithm() do
+    Application.delete_env(:ex_aws_s3, :content_hash_algorithm)
   end
 
   @spec assert_pre_signed_url(


### PR DESCRIPTION
While it was possible to specify an alternate hashing algorithm to ex_aws_s3, the header wasn't correctly appended to the request and was instead appended as `Content-<hash algo>`. AWS looks to require either `Content-MD5` or `x-amz-checksum-<hash algo>` so this implements that behavior.

I also added some unit tests around this. Open to suggestions as to how to improve them since I was a little unsure about modifying the application env during a test.