### PR TITLE
Clarify that presigned URLs are generated locally

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1302,6 +1302,7 @@ defmodule ExAws.S3 do
 
   @doc """
   Generate a pre-signed URL for an object.
+  This is a local operation and does not check whether the bucket or object exists.
 
   When option param `:virtual_host` is `true`, the bucket name will be used in
   the hostname, along with the s3 default host which will look like -


### PR DESCRIPTION
Clarify that presigned URLs are generated locally.

I need to generate multiple of these for a page load. Initially I assumed that this operation had to contact AWS and was looking for a way to request a batch of presigned URLs. But having experimented and looked at the code, I see that this is a local operation, so I can just map over the objects. I thought that was worth noting in the docs.