### PR TITLE
Add x-amz-checksum headers on put_object

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -848,13 +848,21 @@ defmodule ExAws.S3 do
           | {:if_unmodified_since, binary}
           | {:if_match, binary}
           | {:if_none_match, binary}
+          | {:x_amz_checksum_mode, binary}
   @type head_object_opts :: [head_object_opt]
 
   @doc "Determine if an object exists"
   @spec head_object(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t()
   @spec head_object(bucket :: binary, object :: binary, opts :: head_object_opts) ::
           ExAws.Operation.S3.t()
-  @request_headers [:range, :if_modified_since, :if_unmodified_since, :if_match, :if_none_match]
+  @request_headers [
+    :range,
+    :if_modified_since,
+    :if_unmodified_since,
+    :if_match,
+    :if_none_match,
+    :x_amz_checksum_mode
+  ]
   def head_object(bucket, object, opts \\ []) do
     opts = opts |> Map.new()
 

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -939,7 +939,14 @@ defmodule ExAws.S3 do
   @spec put_object(bucket :: binary, object :: binary, body :: binary, opts :: put_object_opts) ::
           ExAws.Operation.S3.t()
   def put_object(bucket, object, body, opts \\ []) do
-    request(:put, bucket, object, body: body, headers: put_object_headers(opts))
+    {ct, content_hash} = calculate_content_hash(body)
+
+    headers =
+      opts
+      |> put_object_headers()
+      |> Map.merge(%{ct => content_hash})
+
+    request(:put, bucket, object, body: body, headers: headers)
   end
 
   @doc "Create or update an object's access control policy"


### PR DESCRIPTION
Pull request #244 added support for `x-amz-checksum` headers when using other hash algorithms than `md5`. This pull request adds the relevant header when using `put_object` so new objects will have the appropriate checksum header.

This will work automatically as long as you have something like this in your configuration:

```elixir
config :ex_aws_s3, :content_hash_algorithm, :sha256 # or :sha or :md5
```

Additionally, this pull request also updates the accepted headers for the `head_object` call so you can get the checksum that was stored in S3 when the object was created. This can be done with the following code:

```elixir
bucket
|> ExAws.S3.head_object(object, x_amz_checksum_mode: "enabled")
|> ExAws.request!()
```