### PR TITLE
Handle errors in parse_complete_multipart_upload

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -105,6 +105,8 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, %{resp | body: parsed_body}}
     end
 
+    def parse_complete_multipart_upload(val), do: val
+
     def parse_list_multipart_uploads({:ok, %{body: xml} = resp}) do
       parsed_body =
         SweetXml.xpath(xml, ~x"//ListMultipartUploadsResult",

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -334,28 +334,36 @@ defmodule ExAws.S3.ParserTest do
     end
   end
 
-  test "#parse_complete_multipart_upload parses CompleteMultipartUploadResult" do
-    complete_multipart_upload_response = """
-    <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-      <Location>https://s3-eu-west-1.amazonaws.com/my-bucket/tmp-copy3.mp4</Location>
-      <Bucket>my-bucket</Bucket>
-      <Key>tmp-copy3.mp4</Key>
-      <ETag>&quot;17fbc0a106abbb6f381aac6e331f2a19-1&quot;</ETag>
-    </CompleteMultipartUploadResult>
-    """
+  describe "#parse_complete_multipart_upload" do
+    test "parses CompleteMultipartUploadResult" do
+      complete_multipart_upload_response = """
+      <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Location>https://s3-eu-west-1.amazonaws.com/my-bucket/tmp-copy3.mp4</Location>
+        <Bucket>my-bucket</Bucket>
+        <Key>tmp-copy3.mp4</Key>
+        <ETag>&quot;17fbc0a106abbb6f381aac6e331f2a19-1&quot;</ETag>
+      </CompleteMultipartUploadResult>
+      """
 
-    result =
-      ExAws.S3.Parsers.parse_complete_multipart_upload(
-        {:ok, %{body: complete_multipart_upload_response}}
-      )
+      result =
+        ExAws.S3.Parsers.parse_complete_multipart_upload(
+          {:ok, %{body: complete_multipart_upload_response}}
+        )
 
-    {:ok, %{body: body}} = result
+      {:ok, %{body: body}} = result
 
-    assert body == %{
-             location: "https://s3-eu-west-1.amazonaws.com/my-bucket/tmp-copy3.mp4",
-             bucket: "my-bucket",
-             key: "tmp-copy3.mp4",
-             etag: "\"17fbc0a106abbb6f381aac6e331f2a19-1\""
-           }
+      assert body == %{
+               location: "https://s3-eu-west-1.amazonaws.com/my-bucket/tmp-copy3.mp4",
+               bucket: "my-bucket",
+               key: "tmp-copy3.mp4",
+               etag: "\"17fbc0a106abbb6f381aac6e331f2a19-1\""
+             }
+    end
+
+    test "handles errors by passing them through" do
+      error = {:error, "error"}
+      result = ExAws.S3.Parsers.parse_complete_multipart_upload(error)
+      assert result == error
+    end
   end
 end


### PR DESCRIPTION
Similar to: https://github.com/ex-aws/ex_aws_s3/pull/226

The goal is avoid crashing on `NoSuchUpload` when calling `ExAws.S3.complete_multipart_upload` with an already completed ID, aborted ID etc, before:

```elixir
     ** (FunctionClauseError) no function clause matching in ExAws.S3.Parsers.parse_complete_multipart_upload/1

     The following arguments were given to ExAws.S3.Parsers.parse_complete_multipart_upload/1:

         # 1
         {:error, {:http_error, 404, %{body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchUpload</Code><Message>The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message><Key>533d0266-ce72-4bc5-b6b0-79157531fc3c</Key><BucketName>test</BucketName><Resource>/test/533d0266-ce72-4bc5-b6b0-79157531fc3c</Resource><RequestId>17E26E884BB5FCA2</RequestId><HostId>16248c6f-1c95-4e00-b177-baab51443613</HostId></Error>", headers: [{"Accept-Ranges", "bytes"}, {"Content-Length", "487"}, {"Content-Security-Policy", "block-all-mixed-content"}, {"Content-Type", "application/xml"}, {"Server", "MinIO"}, {"Strict-Transport-Security", "max-age=31536000; includeSubDomains"}, {"Vary", "Origin"}, {"Vary", "Accept-Encoding"}, {"X-Amz-Request-Id", "17E26E884BB5FCA2"}, {"X-Content-Type-Options", "nosniff"}, {"X-Xss-Protection", "1; mode=block"}, {"Date", "Mon, 15 Jul 2024 16:05:39 GMT"}], status_code: 404}}}

     Attempted function clauses (showing 1 out of 1):

         def parse_complete_multipart_upload({:ok, resp = %{body: xml}})

     code: S3Transfer.complete_upload(session_id, region, "artifact", upload_id, parts)
     stacktrace:
       (ex_aws_s3 2.5.3) lib/ex_aws/s3/parsers.ex:95: ExAws.S3.Parsers.parse_complete_multipart_upload/1
```

after:

```elixir
{:error,
 {:http_error, 404,
  %{
    body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchUpload</Code><Message>The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message><Key>2a3b4947-0367-4453-9e7e-b972f64cb381</Key><BucketName>test</BucketName><Resource>/test/2a3b4947-0367-4453-9e7e-b972f64cb381</Resource><RequestId>17E26E8C3477D8FA</RequestId><HostId>16248c6f-1c95-4e00-b177-baab51443613</HostId></Error>",
    headers: [
      {"Accept-Ranges", "bytes"},
      {"Content-Length", "487"},
      {"Content-Security-Policy", "block-all-mixed-content"},
      {"Content-Type", "application/xml"},
      {"Server", "MinIO"},
      {"Strict-Transport-Security", "max-age=31536000; includeSubDomains"},
      {"Vary", "Origin"},
      {"Vary", "Accept-Encoding"},
      {"X-Amz-Request-Id", "17E26E8C3477D8FA"},
      {"X-Content-Type-Options", "nosniff"},
      {"X-Xss-Protection", "1; mode=block"},
      {"Date", "Mon, 15 Jul 2024 16:05:56 GMT"}
    ],
    status_code: 404
  }}}
```