### PR TITLE
Add empty value checks for delete_object

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -509,13 +509,24 @@ defmodule ExAws.S3 do
   @spec delete_object(bucket :: binary, object :: binary) :: ExAws.Operation.S3.t()
   @spec delete_object(bucket :: binary, object :: binary, opts :: delete_object_opts) ::
           ExAws.Operation.S3.t()
+  @spec delete_object(bucket :: binary, object :: nil) :: no_return
   @request_headers [
     :x_amz_mfa,
     :x_amz_request_payer,
     :x_amz_bypass_governance_retention,
     :x_amz_expected_bucket_owner
   ]
-  def delete_object(bucket, object, opts \\ []) do
+  def delete_object(bucket, object, opts \\ [])
+
+  def delete_object(_bucket, nil = _object, _opts) do
+    raise "object must not be nil"
+  end
+
+  def delete_object(_bucket, "" = _object, _opts) do
+    raise "object must not be empty string"
+  end
+
+  def delete_object(bucket, object, opts) do
     opts = opts |> Map.new()
 
     params =

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -294,6 +294,18 @@ defmodule ExAws.S3Test do
     assert expected == S3.delete_object("bucket", "object")
   end
 
+  test "#delete_object object must not be nil" do
+    assert_raise RuntimeError, "object must not be nil", fn ->
+      S3.delete_object("bucket", nil)
+    end
+  end
+
+  test "#delete_object object must not be empty string" do
+    assert_raise RuntimeError, "object must not be empty string", fn ->
+      S3.delete_object("bucket", "")
+    end
+  end
+
   test "#delete_object version_id option" do
     expected = %Operation.S3{
       body: "",


### PR DESCRIPTION
Add checks for nil and empty string in delete_object. Calling the function with empty values results in an S3 operation that would try to delete the bucket itself.