### PR TITLE
fix: stream! when the client adapter models response headers as lists

### DIFF
--- a/lib/ex_aws/s3/download.ex
+++ b/lib/ex_aws/s3/download.ex
@@ -53,7 +53,13 @@ defmodule ExAws.S3.Download do
     headers
     |> Enum.find(fn {k, _} -> String.downcase(k) == "content-length" end)
     |> elem(1)
-    |> String.to_integer()
+    |> case do
+      content_length when is_binary(content_length) ->
+        content_length |> String.to_integer()
+
+      content_length when is_list(content_length) ->
+        content_length |> List.first() |> String.to_integer()
+    end
   end
 end
 


### PR DESCRIPTION
We are using `:ex_aws_s3` package in a project with `:req` as a client adapter, and we were experiencing an error because the logic to obtain the content size from the response headers assumes that the header is a `binary`. However, `:req` uses a list of strings as a type.

This PR adjusts the code to handle both cases gracefully. Please, let me know if you'd like me to add an integration test where `:req` is used as an adapter.