### PR TITLE
Fix warning for deprecated match

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1246,7 +1246,7 @@ defmodule ExAws.S3 do
       |> Map.merge(source_encryption)
       |> Map.merge(destination_encryption)
 
-    first..last = source_range
+    first..last//_ = source_range
 
     headers =
       headers


### PR DESCRIPTION
Hi!

I noticed that there was a small warning when compiling this project so I went ahead and fixed it. Let me know if this should match on an actual step instead.