### PR TITLE
Handle errors in parse_bucket_object_versions/1

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -189,6 +189,8 @@ if Code.ensure_loaded?(SweetXml) do
 
       {:ok, %{resp | body: parsed_body}}
     end
+
+    def parse_bucket_object_versions(val), do: val
   end
 else
   defmodule ExAws.S3.Parsers do


### PR DESCRIPTION
Currently if an error occurs with the operation parse_bucket_object_versions/1, the error isn't properly returned to the user.

This is the current result if an incorrect region is supplied:

```
iex(2)> ExAws.S3.get_bucket_object_versions("bucket-name", prefix: "object-name") |> ExAws.request(region: "us-west-1")

15:50:07.861 [warning] ExAws: Received redirect, did you specify the correct region?
** (FunctionClauseError) no function clause matching in ExAws.S3.Parsers.parse_bucket_object_versions/1

    The following arguments were given to ExAws.S3.Parsers.parse_bucket_object_versions/1:

        # 1
        {:error, {:http_error, 301, "redirected"}}

    Attempted function clauses (showing 1 out of 1):

        def parse_bucket_object_versions({:ok, resp = %{body: xml}})

    (ex_aws_s3 2.5.6) lib/ex_aws/s3/parsers.ex:151: ExAws.S3.Parsers.parse_bucket_object_versions/1
    iex:2: (file)
```

With my change you now correctly see:

```
iex(2)> ExAws.S3.get_bucket_object_versions("bucket-name", prefix: "object-name") |> ExAws.request(region: "us-west-1")
{:error, {:http_error, 301, "redirected"}}
```