### PR TITLE
Rename get_bucket_object_versions to list_object_versions

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -229,6 +229,16 @@ defmodule ExAws.S3 do
     )
   end
 
+  @doc "List metadata about all versions of the objects in a bucket."
+  @spec list_object_versions(bucket :: binary) :: ExAws.Operation.S3.t()
+  @spec list_object_versions(bucket :: binary, opts :: Keyword.t()) ::
+          ExAws.Operation.S3.t()
+  def list_object_versions(bucket, opts \\ []) do
+    request(:get, bucket, "/", [resource: "versions", params: opts],
+      parser: &ExAws.S3.Parsers.parse_object_versions/1
+    )
+  end
+
   @doc "Get bucket acl"
   @spec get_bucket_acl(bucket :: binary) :: ExAws.Operation.S3.t()
   def get_bucket_acl(bucket) do
@@ -283,14 +293,13 @@ defmodule ExAws.S3 do
     request(:get, bucket, "/", resource: "tagging")
   end
 
-  @doc "Get bucket object versions"
+  @doc "List metadata about all versions of the objects in a bucket."
+  @deprecated "Use list_object_versions/2 instead"
   @spec get_bucket_object_versions(bucket :: binary) :: ExAws.Operation.S3.t()
   @spec get_bucket_object_versions(bucket :: binary, opts :: Keyword.t()) ::
           ExAws.Operation.S3.t()
   def get_bucket_object_versions(bucket, opts \\ []) do
-    request(:get, bucket, "/", [resource: "versions", params: opts],
-      parser: &ExAws.S3.Parsers.parse_bucket_object_versions/1
-    )
+    list_object_versions(bucket, opts)
   end
 
   @doc "Get bucket payment configuration"

--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -148,7 +148,7 @@ if Code.ensure_loaded?(SweetXml) do
 
     def parse_object_tagging(val), do: val
 
-    def parse_bucket_object_versions({:ok, resp = %{body: xml}}) do
+    def parse_object_versions({:ok, resp = %{body: xml}}) do
       parsed_body =
         SweetXml.xpath(xml, ~x"//ListVersionsResult",
           name: ~x"./Name/text()"s,
@@ -190,7 +190,7 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, %{resp | body: parsed_body}}
     end
 
-    def parse_bucket_object_versions(val), do: val
+    def parse_object_versions(val), do: val
   end
 else
   defmodule ExAws.S3.Parsers do

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -196,7 +196,7 @@ defmodule ExAws.S3.ParserTest do
     assert body == %{tags: [%{key: "tag1", value: "val1"}, %{key: "tag2", value: "val2"}]}
   end
 
-  test "#parse_bucket_object_versions parses ListVersionsResult" do
+  test "#parse_object_versions parses ListVersionsResult" do
     response = ~S"""
     <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
     <Name>bucket</Name>
@@ -268,7 +268,7 @@ defmodule ExAws.S3.ParserTest do
     """
 
     assert {:ok, %{body: body}} =
-             ExAws.S3.Parsers.parse_bucket_object_versions({:ok, %{body: response}})
+             ExAws.S3.Parsers.parse_object_versions({:ok, %{body: response}})
 
     %{
       name: name,


### PR DESCRIPTION
Align naming with official S3 clients ([cli](https://docs.aws.amazon.com/cli/latest/reference/s3api/#cli-aws-s3api), [python](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/list_object_versions.html), [js](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Interface/ListObjectVersionsRequest/)).

This makes the `ExAws.S3` function easier to find.