### PR TITLE
add tagging as a put_object opt in typespec

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -954,6 +954,7 @@ defmodule ExAws.S3 do
           | {:meta, amz_meta_opts}
           | {:if_match, binary}
           | {:if_none_match, binary}
+          | {:tagging, binary}
           | acl_opt
           | storage_class_opt
         ]


### PR DESCRIPTION
AWS' `PutObject` api lets you specify a list of tags to add to the object during creation. ExAws.S3 supports this functionality too, but it's missing from the typespec for the function. This led to a little bit of confusion so figured I would help get it fixed.