### PR TITLE
Remove the deprecated Owner DisplayName field.

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -23,8 +23,7 @@ if Code.ensure_loaded?(SweetXml) do
             storage_class: ~x"./StorageClass/text()"s,
             owner: [
               ~x"./Owner"o,
-              id: ~x"./ID/text()"s,
-              display_name: ~x"./DisplayName/text()"s
+              id: ~x"./ID/text()"s
             ]
           ],
           common_prefixes: [
@@ -44,8 +43,7 @@ if Code.ensure_loaded?(SweetXml) do
         |> SweetXml.xpath(~x"//ListAllMyBucketsResult",
           owner: [
             ~x"./Owner",
-            id: ~x"./ID/text()"s,
-            display_name: ~x"./DisplayName/text()"s
+            id: ~x"./ID/text()"s
           ],
           buckets: [
             ~x".//Bucket"l,
@@ -169,7 +167,6 @@ if Code.ensure_loaded?(SweetXml) do
             size: ~x"./Size/text()"s,
             owner: [
               ~x"./Owner"e,
-              display_name: ~x"./DisplayName/text()"s,
               id: ~x"./ID/text()"s
             ]
           ],
@@ -181,7 +178,6 @@ if Code.ensure_loaded?(SweetXml) do
             last_modified: ~x"./LastModified/text()"s,
             owner: [
               ~x"./Owner"e,
-              display_name: ~x"./DisplayName/text()"s,
               id: ~x"./ID/text()"s
             ]
           ]

--- a/test/lib/s3/integration_test.exs
+++ b/test/lib/s3/integration_test.exs
@@ -11,7 +11,6 @@ defmodule ExAws.S3IntegrationTest do
     <ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
       <Owner>
         <ID>fcde9916b80a61ee31a082a6a58a7017df4e4e7a9124e3748dbe9ecc414b9cb8</ID>
-        <DisplayName>ex_aws_s3</DisplayName>
       </Owner>
       <Buckets>
         <Bucket>

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -17,7 +17,6 @@ defmodule ExAws.S3.ParserTest do
         <Size>142863</Size>
         <Owner>
         <ID>canonical-user-id</ID>
-        <DisplayName>display-name</DisplayName>
         </Owner>
         <StorageClass>STANDARD</StorageClass>
       </Contents>
@@ -92,11 +91,9 @@ defmodule ExAws.S3.ParserTest do
       <UploadId>e3gloTamzXlqzgRfKIXrFBhnxCfM35jhktoh.wduDUJHy61R_hjglrx_rLguDGxmOvPeDfzJEK7mxgx7eRwPs9XbYXVmDywrRjbJSmqr.McfkCRDjuI4cdB72IYzfFJl</UploadId>
       <Initiator>
         <ID>arn:aws:iam::123456789012:user/username</ID>
-        <DisplayName>username</DisplayName>
       </Initiator>
       <Owner>
         <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-        <DisplayName>noone@example.com</DisplayName>
       </Owner>
       <StorageClass>STANDARD</StorageClass>
       <PartNumberMarker>0</PartNumberMarker>
@@ -119,11 +116,9 @@ defmodule ExAws.S3.ParserTest do
       <UploadId>e3gloTamzXlqzgRfKIXrFBhnxCfM35jhktoh.wduDUJHy61R_hjglrx_rLguDGxmOvPeDfzJEK7mxgx7eRwPs9XbYXVmDywrRjbJSmqr.McfkCRDjuI4cdB72IYzfFJl</UploadId>
       <Initiator>
         <ID>arn:aws:iam::123456789012:user/username</ID>
-        <DisplayName>username</DisplayName>
       </Initiator>
       <Owner>
         <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-        <DisplayName>noone@example.com</DisplayName>
       </Owner>
       <StorageClass>STANDARD</StorageClass>
       <PartNumberMarker>0</PartNumberMarker>
@@ -215,7 +210,6 @@ defmodule ExAws.S3.ParserTest do
         <StorageClass>STANDARD</StorageClass>
         <Owner>
             <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-            <DisplayName>noone@example.com</DisplayName>
         </Owner>
     </Version>
     <DeleteMarker>
@@ -225,7 +219,6 @@ defmodule ExAws.S3.ParserTest do
         <LastModified>2009-11-12T17:50:30.000Z</LastModified>
         <Owner>
             <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-            <DisplayName>noone@example.com</DisplayName>
         </Owner>
     </DeleteMarker>
     <Version>
@@ -238,7 +231,6 @@ defmodule ExAws.S3.ParserTest do
         <StorageClass>STANDARD</StorageClass>
         <Owner>
             <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-            <DisplayName>noone@example.com</DisplayName>
         </Owner>
     </Version>
     <DeleteMarker>
@@ -248,7 +240,6 @@ defmodule ExAws.S3.ParserTest do
         <LastModified>2009-10-15T17:50:30.000Z</LastModified>
         <Owner>
             <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-            <DisplayName>noone@example.com</DisplayName>
         </Owner>
     </DeleteMarker>
     <Version>
@@ -261,7 +252,6 @@ defmodule ExAws.S3.ParserTest do
         <StorageClass>STANDARD</StorageClass>
         <Owner>
             <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-            <DisplayName>noone@example.com</DisplayName>
         </Owner>
      </Version>
     </ListVersionsResult>
@@ -294,7 +284,6 @@ defmodule ExAws.S3.ParserTest do
     assert version1[:size] == "434234"
     assert version1[:last_modified] == "2009-10-12T17:50:30.000Z"
     assert is_map(version1[:owner])
-    assert version1[:owner][:display_name] == "noone@example.com"
 
     delete_marker1 = Enum.at(delete_markers, 0)
     assert delete_marker1[:key] == "my-second-image.jpg"
@@ -302,7 +291,6 @@ defmodule ExAws.S3.ParserTest do
     assert delete_marker1[:is_latest] == "true"
     assert delete_marker1[:last_modified] == "2009-11-12T17:50:30.000Z"
     assert is_map(delete_marker1[:owner])
-    assert delete_marker1[:owner][:display_name] == "noone@example.com"
   end
 
   describe "#parse_upload_part_copy" do


### PR DESCRIPTION
[Deprecation notice from AWS's docs](https://docs.amazonaws.cn/en_us/AmazonS3/latest/API/API_Owner.html) below:

> End of support notice: Beginning November 21, 2025, Amazon S3 will stop returning DisplayName. Update your applications to use canonical IDs (unique identifier for Amazon accounts), Amazon account ID (12 digit identifier) or IAM ARNs (full resource naming) as a direct replacement of DisplayName.
> Between July 15, 2025 and November 21, 2025, you will begin to see an increasing rate of missing DisplayName in the Owner object.
> This change affects the following Amazon Regions: US East (N. Virginia) Region, US West (N. California) Region, US West (Oregon) Region, Asia Pacific (Singapore) Region, Asia Pacific (Sydney) Region, Asia Pacific (Tokyo) Region, Europe (Ireland) Region, and South America (São Paulo) Region.

Archive links to the docs page listing this deprecation notice (for future reference, in case of page updates):
* [Archive.org](https://web.archive.org/web/20250809173932/https://docs.amazonaws.cn/en_us/AmazonS3/latest/API/API_Owner.html)
* [Archive.is](https://archive.is/LXswG)