### PR TITLE
Improve documentation of `presigned_url/5`

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1971,6 +1971,10 @@ defmodule ExAws.S3 do
   Signed headers can be added to the url by setting option param `:headers` to
   a list of `{"key", "value"}` pairs.
 
+  If you want to set the `Content-Disposition` header, you should set it as a query parameter with
+  the key `response-content-disposition`. Same goes for  `Content-Type`, `Content-Language`,
+  `Expires`, `Cache-Control`, and `Content-Enconding`.
+
   ## Example
   ```
   :s3


### PR DESCRIPTION
Hello,

Here is a suggestion of documentation for how to set some response headers that cannot be set using the headers property.

I have wasted a bit of time on this, so I think this could help people out.

Some S3 clients seem to have specific options for these headers, which hides away this weird behavior. However, simply documenting it seems good enough to me.