### PR TITLE
Add missing parser

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1224,9 +1224,12 @@ defmodule ExAws.S3 do
 
     body_binary = body |> IO.iodata_to_binary()
 
-    request(:post, bucket, "/?delete",
-      body: body_binary,
-      headers: calculate_content_header(body_binary)
+    request(
+      :post,
+      bucket,
+      "/?delete",
+      [body: body_binary, headers: calculate_content_header(body_binary)],
+      parser: &ExAws.S3.Parsers.parse_delete_multiple_objects/1
     )
   end
 

--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -187,6 +187,28 @@ if Code.ensure_loaded?(SweetXml) do
     end
 
     def parse_object_versions(val), do: val
+
+    def parse_delete_multiple_objects({:ok, resp = %{body: xml}}) do
+      parsed_body =
+        SweetXml.xpath(xml, ~x"//DeleteResult",
+          deleted: [
+            ~x"./Deleted"l,
+            key: ~x"./Key/text()"s,
+            version_id: ~x"./VersionId/text()"s
+          ],
+          errors: [
+            ~x"./Error"l,
+            key: ~x"./Key/text()"s,
+            version_id: ~x"./VersionId/text()"s,
+            code: ~x"./Code/text()"s,
+            message: ~x"./Message/text()"s
+          ]
+        )
+
+      {:ok, %{resp | body: parsed_body}}
+    end
+
+    def parse_delete_multiple_objects(val), do: val
   end
 else
   defmodule ExAws.S3.Parsers do
@@ -201,5 +223,6 @@ else
     def parse_list_parts(_val), do: missing_xml_parser()
     def parse_object_tagging(_val), do: missing_xml_parser()
     def parse_object_versions(_val), do: missing_xml_parser()
+    def parse_delete_multiple_objects(_val), do: missing_xml_parser()
   end
 end

--- a/test/lib/s3/parser_test.exs
+++ b/test/lib/s3/parser_test.exs
@@ -354,4 +354,132 @@ defmodule ExAws.S3.ParserTest do
       assert result == error
     end
   end
+
+  describe "#parse_delete_multiple_objects" do
+    test "returns deleted entries and no errors when all objects succeed" do
+      response = ~S"""
+      <?xml version="1.0" encoding="UTF-8"?>
+      <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Deleted><Key>my-image.jpg</Key></Deleted>
+        <Deleted><Key>my-second-image.jpg</Key></Deleted>
+      </DeleteResult>
+      """
+
+      {:ok, %{body: body}} =
+        ExAws.S3.Parsers.parse_delete_multiple_objects({:ok, %{body: response}})
+
+      assert body.deleted == [
+               %{key: "my-image.jpg", version_id: ""},
+               %{key: "my-second-image.jpg", version_id: ""}
+             ]
+
+      assert body.errors == []
+    end
+
+    test "returns both deleted and error entries on partial failure" do
+      response = ~S"""
+      <?xml version="1.0" encoding="UTF-8"?>
+      <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Deleted><Key>my-image.jpg</Key></Deleted>
+        <Error>
+          <Key>my-second-image.jpg</Key>
+          <Code>AccessDenied</Code>
+          <Message>Access Denied</Message>
+        </Error>
+      </DeleteResult>
+      """
+
+      {:ok, %{body: body}} =
+        ExAws.S3.Parsers.parse_delete_multiple_objects({:ok, %{body: response}})
+
+      assert body.deleted == [%{key: "my-image.jpg", version_id: ""}]
+
+      assert body.errors == [
+               %{
+                 key: "my-second-image.jpg",
+                 version_id: "",
+                 code: "AccessDenied",
+                 message: "Access Denied"
+               }
+             ]
+    end
+
+    test "returns errors and no deleted entries when all objects fail" do
+      response = ~S"""
+      <?xml version="1.0" encoding="UTF-8"?>
+      <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Error>
+          <Key>my-image.jpg</Key>
+          <Code>NoSuchKey</Code>
+          <Message>The specified key does not exist.</Message>
+        </Error>
+      </DeleteResult>
+      """
+
+      {:ok, %{body: body}} =
+        ExAws.S3.Parsers.parse_delete_multiple_objects({:ok, %{body: response}})
+
+      assert body.deleted == []
+
+      assert body.errors == [
+               %{
+                 key: "my-image.jpg",
+                 version_id: "",
+                 code: "NoSuchKey",
+                 message: "The specified key does not exist."
+               }
+             ]
+    end
+
+    test "returns empty lists for an empty DeleteResult (quiet mode)" do
+      response = ~S"""
+      <?xml version="1.0" encoding="UTF-8"?>
+      <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+      """
+
+      {:ok, %{body: body}} =
+        ExAws.S3.Parsers.parse_delete_multiple_objects({:ok, %{body: response}})
+
+      assert body.deleted == []
+      assert body.errors == []
+    end
+
+    test "includes VersionId in entries for versioned buckets" do
+      response = ~S"""
+      <?xml version="1.0" encoding="UTF-8"?>
+      <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Deleted>
+          <Key>my-image.jpg</Key>
+          <VersionId>3/L4kqtJl40Nr8X8gdRQBpUMLUo</VersionId>
+        </Deleted>
+        <Error>
+          <Key>my-second-image.jpg</Key>
+          <VersionId>03jpff543dhffds434rfdsFDN943fdsFkdmqnh892</VersionId>
+          <Code>AccessDenied</Code>
+          <Message>Access Denied</Message>
+        </Error>
+      </DeleteResult>
+      """
+
+      {:ok, %{body: body}} =
+        ExAws.S3.Parsers.parse_delete_multiple_objects({:ok, %{body: response}})
+
+      assert body.deleted == [%{key: "my-image.jpg", version_id: "3/L4kqtJl40Nr8X8gdRQBpUMLUo"}]
+
+      assert body.errors == [
+               %{
+                 key: "my-second-image.jpg",
+                 version_id: "03jpff543dhffds434rfdsFDN943fdsFkdmqnh892",
+                 code: "AccessDenied",
+                 message: "Access Denied"
+               }
+             ]
+    end
+
+    test "handles errors by passing them through" do
+      error = {:error, "error"}
+      result = ExAws.S3.Parsers.parse_delete_multiple_objects(error)
+      assert result == error
+    end
+  end
 end

--- a/test/lib/s3_test.exs
+++ b/test/lib/s3_test.exs
@@ -339,7 +339,8 @@ defmodule ExAws.S3Test do
       bucket: "bucket",
       path: "/?delete",
       headers: %{"content-md5" => "G9Pq8w8AQUesREJndxKbKw=="},
-      http_method: :post
+      http_method: :post,
+      parser: &ExAws.S3.Parsers.parse_delete_multiple_objects/1
     }
 
     assert expected ==
@@ -359,7 +360,8 @@ defmodule ExAws.S3Test do
       bucket: "bucket",
       path: "/?delete",
       headers: %{"x-amz-checksum-sha1" => "1uLbLBmwtufR1/csrQPCAONFeKU="},
-      http_method: :post
+      http_method: :post,
+      parser: &ExAws.S3.Parsers.parse_delete_multiple_objects/1
     }
 
     assert expected ==
@@ -381,7 +383,8 @@ defmodule ExAws.S3Test do
       bucket: "bucket",
       path: "/?delete",
       headers: %{"x-amz-checksum-sha256" => "Hsce+MZp64Uy8CwyResJ3y13YGw6jDAAdVGFmFPKPSs="},
-      http_method: :post
+      http_method: :post,
+      parser: &ExAws.S3.Parsers.parse_delete_multiple_objects/1
     }
 
     assert expected ==


### PR DESCRIPTION
`ExAws.S3.delete_multiple_objects/3` had no parser registered, so callers always had to parse the raw XML response.